### PR TITLE
chore(config): add Angular-specific entries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,16 @@ lerna-debug.log*
 .env.test.local
 .env.production.local
 
+# Angular specific
+.angular/
+.angular/cache/
+coverage/
+e2e/results/
+e2e/reports/
+*.tsbuildinfo
+.nx/cache/
+.sass-cache/
+
 # Python (for ML models and scripts)
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
### What does this PR do?
This PR adds Angular-specific entries to the root `.gitignore` file to prepare for frontend development.

### Why is this change needed?
When we create the Angular frontend service, these entries will prevent Angular build artifacts, cache files, and test outputs from being committed to the repository.

### How can a reviewer test this?
1. Review the added entries in `.gitignore`
2. Verify entries follow Angular best practices for 2024/2025
3. Confirm no existing functionality is affected