### PR TITLE
docs(scripts): add descriptive headers to development scripts

### DIFF
--- a/scripts/devdown.bat
+++ b/scripts/devdown.bat
@@ -1,2 +1,11 @@
 @echo off
+REM
+REM Development Environment Shutdown Script (Windows)
+REM 
+REM This script stops and removes all containers from the development environment.
+REM It will cleanly shut down PostgreSQL database, pgAdmin, and remove the 
+REM associated Docker network to free up system resources.
+REM
+REM Usage: scripts\devdown.bat
+REM
 docker compose -f docker-compose.dev.yml down

--- a/scripts/devdown.sh
+++ b/scripts/devdown.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
+#
+# Development Environment Shutdown Script
+# 
+# This script stops and removes all containers from the development environment.
+# It will cleanly shut down PostgreSQL database, pgAdmin, and remove the 
+# associated Docker network to free up system resources.
+#
+# Usage: ./scripts/devdown.sh
+#
 docker compose -f docker-compose.dev.yml down

--- a/scripts/devup.bat
+++ b/scripts/devup.bat
@@ -1,2 +1,11 @@
 @echo off
+REM
+REM Development Environment Startup Script (Windows)
+REM 
+REM This script starts the development environment using Docker Compose.
+REM It will start all required services (PostgreSQL database, pgAdmin) 
+REM in detached mode, allowing you to continue working in the command prompt.
+REM
+REM Usage: scripts\devup.bat
+REM
 docker compose -f docker-compose.dev.yml up -d

--- a/scripts/devup.sh
+++ b/scripts/devup.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
+#
+# Development Environment Startup Script
+# 
+# This script starts the development environment using Docker Compose.
+# It will start all required services (PostgreSQL database, pgAdmin) 
+# in detached mode, allowing you to continue working in the terminal.
+#
+# Usage: ./scripts/devup.sh
+#
 docker compose -f docker-compose.dev.yml up -d


### PR DESCRIPTION
### What does this PR do?
This PR adds comprehensive documentation headers to all four development scripts in the `/scripts` directory. Each script now includes clear descriptions of its purpose, the services it affects (PostgreSQL database and pgAdmin), operational behavior, and usage instructions with platform-specific path syntax.

### Why is this change needed?
The original scripts lacked documentation, making it difficult for team members (especially new ones) to understand what each script does without reading the code. Adding these headers makes the scripts self-documenting and improves the developer experience by providing clear usage instructions for both Unix/macOS and Windows environments.

### How can a reviewer test this?
1. Check that all four script files have descriptive headers:
   - `scripts/devup.sh` - Unix/macOS startup script
   - `scripts/devdown.sh` - Unix/macOS shutdown script  
   - `scripts/devup.bat` - Windows startup script
   - `scripts/devdown.bat` - Windows shutdown script

2. Verify the documentation explains:
   - What each script does (starts/stops development environment)
   - Which services are affected (PostgreSQL, pgAdmin)
   - How the scripts operate (detached mode, cleanup process)
   - Correct usage syntax for each platform

3. Optionally test the scripts still work correctly:
   - Run `./scripts/devup.sh` to start the development environment
   - Verify containers are running with `docker ps`
   - Run `./scripts/devdown.sh` to stop and clean up
   - Confirm no containers remain with `docker ps`

### Files Changed:
- `scripts/devup.sh` - Added startup documentation header
- `scripts/devdown.sh` - Added shutdown documentation header  
- `scripts/devup.bat` - Added Windows startup documentation header
- `scripts/devdown.bat` - Added Windows shutdown documentation header