### PR TITLE
docs(openapi): compact spec, relax UoM, case-insensitive sort, improved consistency.

### DIFF
--- a/shared/api-contracts/openapi/inventory-service-openapi-v1-0_2_0.yaml
+++ b/shared/api-contracts/openapi/inventory-service-openapi-v1-0_2_0.yaml
@@ -1,0 +1,827 @@
+openapi: 3.0.0
+info:
+  title: Inventory Service API
+  version: 0.5.0
+  description: >-
+    CRUD for master data (Products, Suppliers, Customers) with comprehensive filtering support.
+    Integer IDs, no auth. Timestamps are read-only and maintained in app code (e.g., JPA auditing).
+    
+    ## Filtering Rules
+    - **AND logic** across different parameter types (narrows results)
+    - **OR logic** within repeatable parameters (broadens within that field)
+    - **Case-insensitive** text matching for better UX
+    - **Unknown parameters** return HTTP 400 to catch typos early
+    - **Range parameters** are inclusive (gte = greater than or equal, lte = less than or equal)
+    - **Date-time parameters** must be in UTC (ending with Z or +00:00)
+    
+    ## Performance Notes
+    - Text search (`q` parameter) performs substring matching and may be slow on large datasets
+    - Maximum pagination window is 10,000 records (page * size cannot exceed 10,000)
+    - All filter parameters use database indexes for optimal performance
+    
+servers:
+  - url: http://localhost:8000
+    description: Local dev
+  - url: http://inventory-service:8000
+    description: In-cluster name
+
+components:
+  parameters:
+    # ---- Pagination Parameters ----
+    PageParam: 
+      in: query
+      name: page
+      description: "0-based page number"
+      schema: {type: integer, minimum: 0, default: 0}
+    
+    SizeParam: 
+      in: query
+      name: size
+      description: "Page size (max 200)"
+      schema: {type: integer, minimum: 1, maximum: 200, default: 20}
+    
+    SortParam: 
+      in: query
+      name: sort
+      description: "Sort clause with format: field,direction (asc|desc). Invalid fields return 400."
+      schema: {type: string, pattern: '^[A-Za-z]+,([Aa][Ss][Cc]|[Dd][Ee][Ss][Cc])$', example: "productName,asc"}
+    
+    # ---- Common Filter Parameters ----
+    QueryParam:
+      in: query
+      name: q
+      description: >-
+        Text search query. Searches across name and description/email fields.
+        Minimum 2 characters required. Case-insensitive substring match.
+        Note: This performs a substring search and may be slow on very large datasets.
+      schema: {type: string, minLength: 2, example: "banana"}
+    
+    UpdatedAfterParam:
+      in: query
+      name: updated_after
+      description: >-
+        Filter records updated after this timestamp (inclusive).
+        Must be in UTC format with Z suffix or +00:00 offset.
+      schema: {type: string, format: date-time, example: "2025-08-01T00:00:00Z"}
+    
+    # ---- Product-specific Filter Parameters ----
+    CategoryParam:
+      in: query
+      name: category
+      description: >-
+        Filter by product category. Case-insensitive exact match.
+        Can be repeated for OR logic (e.g., category=Snacks&category=Drinks).
+      schema: {type: array, items: {type: string, maxLength: 100}, minItems: 1}
+      style: form
+      explode: true
+      example: ["Electronics", "Accessories"]
+    
+    UomParam:
+      in: query
+      name: uom
+      description: >-
+        Filter by unit of measure. Case-insensitive exact match.
+        Can be repeated for OR logic. Allowed values (validated server-side & DB): adet, ton, kg, g, lt, ml, koli, paket, çuval, şişe.
+      schema: {type: array, items: {type: string}, minItems: 1}
+      style: form
+      explode: true
+      example: ["kg", "g"]
+    
+    PriceGteParam:
+      in: query
+      name: price_gte
+      description: "Minimum price (inclusive). Must be >= 0 and <= 99999999.99"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 10.00}
+    
+    PriceLteParam:
+      in: query
+      name: price_lte
+      description: "Maximum price (inclusive). Must be >= price_gte if both provided"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 50.00}
+    
+    SafetyGteParam:
+      in: query
+      name: safety_gte
+      description: "Minimum safety stock level (inclusive)"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 0}
+    
+    SafetyLteParam:
+      in: query
+      name: safety_lte
+      description: "Maximum safety stock level (inclusive)"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 5}
+    
+    ReorderGteParam:
+      in: query
+      name: reorder_gte
+      description: "Minimum reorder point (inclusive)"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 10}
+    
+    ReorderLteParam:
+      in: query
+      name: reorder_lte
+      description: "Maximum reorder point (inclusive)"
+      schema: {type: number, format: double, minimum: 0, maximum: 99999999.99, example: 25}
+    
+    # ---- Supplier/Customer Filter Parameters ----
+    CityParam:
+      in: query
+      name: city
+      description: >-
+        Filter by city. Case-insensitive exact match.
+        Can be repeated for OR logic (e.g., city=Istanbul&city=Ankara).
+      schema: {type: array, items: {type: string, maxLength: 50}, minItems: 1}
+      style: form
+      explode: true
+      example: ["Istanbul", "Ankara"]
+    
+    # ---- Customer-specific Filter Parameters ----
+    SegmentParam:
+      in: query
+      name: segment
+      description: >-
+        Filter by customer segment. Exact match against enum values.
+        Can be repeated for OR logic.
+      schema: {type: array, items: {type: string, enum: [INDIVIDUAL, SME, CORPORATE, ENTERPRISE, OTHER]}, minItems: 1}
+      style: form
+      explode: true
+      example: ["SME", "CORPORATE"]
+
+  schemas:
+    # -----------------------------
+    # ENUMS (from V1__types.sql)
+    # -----------------------------
+    CustomerSegment: 
+      type: string
+      description: "Business segment classification for customer categorization and pricing strategies"
+      enum: [INDIVIDUAL, SME, CORPORATE, ENTERPRISE, OTHER]
+      example: SME
+
+    # -----------------------------
+    # Shared pagination & errors
+    # -----------------------------
+    PageMeta:
+      type: object
+      properties:
+        page: {type: integer, description: "Current page number (0-based)"}
+        size: {type: integer, description: "Number of elements per page"}
+        totalElements: {type: integer, description: "Total number of elements across all pages"}
+        totalPages: {type: integer, description: "Total number of pages available"}
+    
+    ErrorResponse:
+      type: object
+      properties:
+        status: 
+          type: integer
+          example: 400
+        error: 
+          type: string
+          example: "Bad Request"
+        message: 
+          type: string
+          example: "Validation failed: reorderPoint must be greater than or equal to safetyStock."
+        path: 
+          type: string
+          example: "/api/v1/products"
+        timestamp: 
+          type: string
+          format: date-time
+        details:
+          type: object
+          description: "Additional error details for filter validation"
+          properties:
+            invalidParams:
+              type: array
+              items:
+                type: string
+              example: ["categor_y", "pricee"]
+            validationErrors:
+              type: object
+              additionalProperties:
+                type: string
+              example:
+                price_gte: "Must be greater than or equal to 0"
+                q: "Minimum length is 2 characters"
+
+    # -----------------------------
+    # Product
+    # -----------------------------
+    Product:
+      type: object
+      required: [productId, productName, category, unitOfMeasure, safetyStock, reorderPoint, currentPrice]
+      properties:
+        productId: {type: integer, format: int64, example: 101, description: "Unique identifier for the product"}
+        productName: {type: string, maxLength: 200, example: "iPhone 15 Pro", description: "Name of the product (max 200 characters)"}
+        description: {type: string, nullable: true, example: "Latest model with advanced camera system", description: "Optional detailed description of the product"}
+        category: {type: string, maxLength: 100, example: "Electronics", description: "Product category for organization and filtering (max 100 characters)"}
+        unitOfMeasure: {type: string, maxLength: 20, minLength: 1, example: "adet", description: "Unit of measurement. Allowed: adet, ton, kg, g, lt, ml, koli, paket, çuval, şişe"}
+        safetyStock: {type: number, format: double, minimum: 0, example: 10, description: "Minimum stock level that triggers reordering alerts"}
+        reorderPoint: {type: number, format: double, minimum: 0, example: 25, description: "Stock level threshold for automatic reordering (must be >= safetyStock)"}
+        currentPrice: {type: number, format: double, minimum: 0, example: 1299.99, description: "Current selling price of the product"}
+        createdAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the product was created"}
+        updatedAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the product was last updated"}
+    
+    ProductCreate:
+      type: object
+      required: [productName, category, unitOfMeasure, safetyStock, reorderPoint, currentPrice]
+      properties:
+        productName: {type: string, minLength: 1, maxLength: 200, description: "Name of the product (1-200 characters)"}
+        description: {type: string, nullable: true, description: "Optional detailed description of the product"}
+        category: {type: string, minLength: 1, maxLength: 100, description: "Product category for organization (1-100 characters)"}
+        unitOfMeasure: {type: string, minLength: 1, maxLength: 20, example: "adet", description: "Unit of measurement. Allowed: adet, ton, kg, g, lt, ml, koli, paket, çuval, şişe"}
+        safetyStock: {type: number, format: double, minimum: 0, maximum: 99999999.99, description: "Minimum stock level that triggers reordering alerts"}
+        reorderPoint: {type: number, format: double, minimum: 0, maximum: 99999999.99, description: "Stock level threshold for automatic reordering (must be >= safetyStock)"}
+        currentPrice: {type: number, format: double, minimum: 0, maximum: 99999999.99, description: "Current selling price of the product"}
+    
+    ProductUpdate:
+      allOf:
+        - $ref: '#/components/schemas/ProductCreate'
+
+    PageProduct:
+      type: object
+      properties:
+        content:
+          type: array
+          items: 
+            $ref: '#/components/schemas/Product'
+        page: 
+          $ref: '#/components/schemas/PageMeta'
+
+    # -----------------------------
+    # Supplier
+    # -----------------------------
+    Supplier:
+      type: object
+      required: [supplierId, supplierName, email, phone, city]
+      properties:
+        supplierId: {type: integer, format: int64, example: 11, description: "Unique identifier for the supplier"}
+        supplierName: {type: string, maxLength: 200, example: "Acme Foods Ltd", description: "Name of the supplier company (max 200 characters)"}
+        email: {type: string, format: email, maxLength: 100, example: "contact@acmefoods.com", description: "Unique email address for the supplier (max 100 characters)"}
+        phone: {type: string, maxLength: 30, pattern: "^[+]?[0-9\\s\\-\\(\\)]+$", example: "+90 212 555 0123", description: "Contact phone number (max 30 characters)"}
+        city: {type: string, maxLength: 50, example: "Istanbul", description: "City where the supplier is located (max 50 characters)"}
+        createdAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the supplier was created"}
+        updatedAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the supplier was last updated"}
+    
+    SupplierCreate:
+      type: object
+      required: [supplierName, email, phone, city]
+      properties:
+        supplierName: {type: string, minLength: 1, maxLength: 200, description: "Name of the supplier company (1-200 characters)"}
+        email: {type: string, format: email, maxLength: 100, description: "Unique email address for the supplier (max 100 characters)"}
+        phone: {type: string, maxLength: 30, pattern: "^[+]?[0-9\\s\\-\\(\\)]+$", description: "Contact phone number (max 30 characters)"}
+        city: {type: string, minLength: 1, maxLength: 50, description: "City where the supplier is located (1-50 characters)"}
+    
+    SupplierUpdate:
+      allOf:
+        - $ref: '#/components/schemas/SupplierCreate'
+
+    PageSupplier:
+      type: object
+      properties:
+        content:
+          type: array
+          items: 
+            $ref: '#/components/schemas/Supplier'
+        page: 
+          $ref: '#/components/schemas/PageMeta'
+
+    # -----------------------------
+    # Customer
+    # -----------------------------
+    Customer:
+      type: object
+      required: [customerId, customerName, customerSegment, email, phone, city]
+      properties:
+        customerId: {type: integer, format: int64, example: 501, description: "Unique identifier for the customer"}
+        customerName: {type: string, maxLength: 200, example: "Blue Mart Electronics", description: "Name of the customer or company (max 200 characters)"}
+        customerSegment: {$ref: '#/components/schemas/CustomerSegment', description: "Business segment classification of the customer"}
+        email: {type: string, format: email, maxLength: 100, example: "orders@bluemart.com", description: "Unique email address for the customer (max 100 characters)"}
+        phone: {type: string, maxLength: 30, pattern: "^[+]?[0-9\\s\\-\\(\\)]+$", example: "+90 532 123 4567", description: "Contact phone number (max 30 characters)"}
+        city: {type: string, maxLength: 50, example: "Ankara", description: "City where the customer is located (max 50 characters)"}
+        createdAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the customer was created"}
+        updatedAt: {type: string, format: date-time, readOnly: true, description: "Timestamp when the customer was last updated"}
+    
+    CustomerCreate:
+      type: object
+      required: [customerName, customerSegment, email, phone, city]
+      properties:
+        customerName: {type: string, minLength: 1, maxLength: 200, description: "Name of the customer or company (1-200 characters)"}
+        customerSegment: {$ref: '#/components/schemas/CustomerSegment', description: "Business segment classification of the customer"}
+        email: {type: string, format: email, maxLength: 100, description: "Unique email address for the customer (max 100 characters)"}
+        phone: {type: string, maxLength: 30, pattern: "^[+]?[0-9\\s\\-\\(\\)]+$", description: "Contact phone number (max 30 characters)"}
+        city: {type: string, minLength: 1, maxLength: 50, description: "City where the customer is located (1-50 characters)"}
+        
+    CustomerUpdate:
+      allOf:
+        - $ref: '#/components/schemas/CustomerCreate'
+
+    PageCustomer:
+      type: object
+      properties:
+        content:
+          type: array
+          items: 
+            $ref: '#/components/schemas/Customer'
+        page: 
+          $ref: '#/components/schemas/PageMeta'
+
+paths:
+  # -----------------
+  # Products
+  # -----------------
+  /api/v1/products:
+    get:
+      tags: [Products]
+      summary: Retrieve paginated list of products with filtering and sorting
+      description: >-
+        Returns a paginated list of products. Supports multiple filter parameters that combine with AND logic.
+        Repeatable parameters (category, uom) use OR logic within the same parameter type.
+        Unknown query parameters will result in HTTP 400.
+        Default sort is by productName ascending. Whitelisted sort fields: productName, category, currentPrice, updatedAt.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/QueryParam'
+        - $ref: '#/components/parameters/CategoryParam'
+        - $ref: '#/components/parameters/UomParam'
+        - $ref: '#/components/parameters/PriceGteParam'
+        - $ref: '#/components/parameters/PriceLteParam'
+        - $ref: '#/components/parameters/SafetyGteParam'
+        - $ref: '#/components/parameters/SafetyLteParam'
+        - $ref: '#/components/parameters/ReorderGteParam'
+        - $ref: '#/components/parameters/ReorderLteParam'
+        - $ref: '#/components/parameters/UpdatedAfterParam'
+      responses:
+        '200':
+          description: Paged products matching filter criteria
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/PageProduct'
+              examples:
+                filtered:
+                  summary: "Filtered products example"
+                  value:
+                    content:
+                      - productId: 101
+                        productName: "Bananas"
+                        category: "Fruits"
+                        unitOfMeasure: "kg"
+                        safetyStock: 50
+                        reorderPoint: 100
+                        currentPrice: 2.99
+                        createdAt: "2025-01-15T10:00:00Z"
+                        updatedAt: "2025-08-20T14:30:00Z"
+                    page:
+                      page: 0
+                      size: 20
+                      totalElements: 1
+                      totalPages: 1
+        '400':
+          description: Invalid filter parameters or validation error
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unknownParam:
+                  summary: "Unknown parameter error"
+                  value:
+                    status: 400
+                    error: "Bad Request"
+                    message: "Unknown query parameters: categor_y"
+                    path: "/api/v1/products"
+                    timestamp: "2025-08-28T10:00:00Z"
+                    details:
+                      invalidParams: ["categor_y"]
+                rangeError:
+                  summary: "Invalid range error"
+                  value:
+                    status: 400
+                    error: "Bad Request"
+                    message: "price_gte cannot be greater than price_lte"
+                    path: "/api/v1/products"
+                    timestamp: "2025-08-28T10:00:00Z"
+    
+    post:
+      tags: [Products]
+      summary: Create a new product with required fields
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/ProductCreate'
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location: 
+              description: "URL of the created product"
+              schema: 
+                type: string
+                format: uri
+                example: "/api/v1/products/123"
+          content:
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Product'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+  
+  /api/v1/products/{productId}:
+    get:
+      tags: [Products]
+      summary: Retrieve detailed information for a specific product
+      parameters: 
+        - in: path
+          name: productId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '200': 
+          description: OK
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Product'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    put:
+      tags: [Products]
+      summary: Update product with all required fields
+      parameters: 
+        - in: path
+          name: productId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/ProductUpdate'
+      responses:
+        '200': 
+          description: Updated
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Product'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    delete:
+      tags: [Products]
+      summary: Permanently remove a product from the inventory system
+      parameters: 
+        - in: path
+          name: productId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '204': 
+          description: Deleted
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # -----------------
+  # Suppliers
+  # -----------------
+  /api/v1/suppliers:
+    get:
+      tags: [Suppliers]
+      summary: Retrieve paginated list of suppliers with filtering and sorting
+      description: >-
+        Returns a paginated list of suppliers. Supports multiple filter parameters that combine with AND logic.
+        City parameter can be repeated for OR logic. Unknown query parameters will result in HTTP 400.
+        Default sort is by supplierName ascending. Whitelisted sort fields: supplierName, updatedAt.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/QueryParam'
+        - $ref: '#/components/parameters/CityParam'
+        - $ref: '#/components/parameters/UpdatedAfterParam'
+      responses:
+        '200':
+          description: Paged suppliers matching filter criteria
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/PageSupplier'
+        '400':
+          description: Invalid filter parameters or validation error
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    post:
+      tags: [Suppliers]
+      summary: Register a new supplier with required fields
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/SupplierCreate'
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location: 
+              description: "URL of the created supplier"
+              schema: 
+                type: string
+                format: uri
+                example: "/api/v1/suppliers/456"
+          content:
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Supplier'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '409': 
+          description: Duplicate email
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+  
+  /api/v1/suppliers/{supplierId}:
+    get:
+      tags: [Suppliers]
+      summary: Retrieve detailed information for a specific supplier
+      parameters: 
+        - in: path
+          name: supplierId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '200': 
+          description: OK
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Supplier'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    put:
+      tags: [Suppliers]
+      summary: Update supplier with all required fields
+      parameters: 
+        - in: path
+          name: supplierId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/SupplierUpdate'
+      responses:
+        '200': 
+          description: Updated
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Supplier'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '409': 
+          description: Duplicate email
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    delete:
+      tags: [Suppliers]
+      summary: Permanently remove a supplier from the system
+      parameters: 
+        - in: path
+          name: supplierId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '204': 
+          description: Deleted
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # -----------------
+  # Customers
+  # -----------------
+  /api/v1/customers:
+    get:
+      tags: [Customers]
+      summary: Retrieve paginated list of customers with filtering and sorting
+      description: >-
+        Returns a paginated list of customers. Supports multiple filter parameters that combine with AND logic.
+        City and segment parameters can be repeated for OR logic. Unknown query parameters will result in HTTP 400.
+        Default sort is by customerName ascending. Whitelisted sort fields: customerName, updatedAt.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/QueryParam'
+        - $ref: '#/components/parameters/SegmentParam'
+        - $ref: '#/components/parameters/CityParam'
+        - $ref: '#/components/parameters/UpdatedAfterParam'
+      responses:
+        '200':
+          description: Paged customers matching filter criteria
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/PageCustomer'
+        '400':
+          description: Invalid filter parameters or validation error
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    post:
+      tags: [Customers]
+      summary: Register a new customer with required fields
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/CustomerCreate'
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location: 
+              description: "URL of the created customer"
+              schema: 
+                type: string
+                format: uri
+                example: "/api/v1/customers/789"
+          content:
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Customer'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '409': 
+          description: Duplicate email
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+  
+  /api/v1/customers/{customerId}:
+    get:
+      tags: [Customers]
+      summary: Retrieve detailed information for a specific customer
+      parameters: 
+        - in: path
+          name: customerId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '200': 
+          description: OK
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Customer'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    put:
+      tags: [Customers]
+      summary: Update customer with all required fields
+      parameters: 
+        - in: path
+          name: customerId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content: 
+          application/json: 
+            schema: 
+              $ref: '#/components/schemas/CustomerUpdate'
+      responses:
+        '200': 
+          description: Updated
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/Customer'
+        '400': 
+          description: Invalid input
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+        '409': 
+          description: Duplicate email
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'
+    
+    delete:
+      tags: [Customers]
+      summary: Permanently remove a customer from the system
+      parameters: 
+        - in: path
+          name: customerId
+          required: true
+          schema: 
+            type: integer
+            format: int64
+      responses:
+        '204': 
+          description: Deleted
+        '404': 
+          description: Not found
+          content: 
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/ErrorResponse'


### PR DESCRIPTION
### What does this PR do?
- Updates the Inventory Service OpenAPI spec to a more compact style and formalizes filtering across resources.
- Introduces consistent path params: `{productId}`, `{supplierId}`, `{customerId}`.
- Relaxes `UomParam` (no OpenAPI enum) to avoid client coupling; allowed values documented, validation stays in code/DB.
- Makes `SortParam` direction case-insensitive (`asc|ASC|desc|DESC`).

### Why is this change needed?
- Filtering is a core UX requirement; this documents behavior precisely and consistently.
- Avoids breaking clients via OpenAPI enums for UoM while still guiding with documented allowed values.
- Ensures consistent path and query parameter naming for clarity and easier integration.
- Improves readability/maintainability of the spec via compact inlining where appropriate.

### Filtering model (applies to list endpoints)
- AND logic across different parameter types (narrows results).
- OR logic within the same repeatable parameter (e.g., `category=Fruits&category=Drinks`).
- `q` text search is case-insensitive substring match across name/description-like fields.
- Range parameters are inclusive:
  - `price_gte`, `price_lte`
  - `safety_gte`, `safety_lte`
  - `reorder_gte`, `reorder_lte`
- `updated_after` must be UTC (`Z` or `+00:00`).
- Unknown parameters → HTTP 400 (explicitly documented).
- Sorting: `sort=field,asc|desc` with case-insensitive direction.
- Pagination: standard `page`, `size`; large-window guidance documented (max window 10,000) for clients.

### Parameters by resource
- Products GET /api/v1/products
  - Pagination: `page`, `size`
  - Sort: `sort` (whitelist stated in endpoint description)
  - Text: `q`
  - Filters:
    - `category` (repeatable, OR within param)
    - `uom` (repeatable; schema is free-text; allowed values listed in description: `adet, ton, kg, g, lt, ml, koli, paket, çuval, şişe`)
    - Ranges: `price_gte`, `price_lte`, `safety_gte`, `safety_lte`, `reorder_gte`, `reorder_lte`
    - `updated_after`
- Suppliers GET /api/v1/suppliers
  - Pagination: `page`, `size`
  - Sort: `sort`
  - Text: `q`
  - Filters: `city` (repeatable), `updated_after`
- Customers GET /api/v1/customers
  - Pagination: `page`, `size`
  - Sort: `sort`
  - Text: `q`
  - Filters: `city` (repeatable), `segment` (repeatable, enum), `updated_after`

### How can a reviewer test this?
- Syntax validation: load the YAML into Swagger Editor or `openapi-cli lint` (no linter errors expected).
- Check key regex and param details:
  - Sort regex: `^[A-Za-z]+,([Aa][Ss][Cc]|[Dd][Ee][Ss][Cc])$` (accepts ASC/DESC any case)
  - `UomParam` has no enum; allowed list only in description; values include diacritics `çuval`, `şişe`.
- Example requests (assuming local server at http://localhost:8000/api/v1):

Products
- Combined filtering with OR and ranges:
  - GET `/api/v1/products?q=phone&category=Electronics&category=Accessories&price_gte=100&price_lte=1500&uom=adet&uom=kg&updated_after=2025-08-01T00:00:00Z&sort=productName,ASC&page=0&size=20`
- Validation cases:
  - Unknown param → 400:
    - GET `/api/v1/products?categor_y=Fruits`
  - Invalid range → 400:
    - GET `/api/v1/products?price_gte=100&price_lte=50`
  - Sort direction uppercase accepted:
    - GET `/api/v1/products?sort=currentPrice,DESC`

Suppliers
- City OR + search:
  - GET `/api/v1/suppliers?city=Istanbul&city=Ankara&q=foods&sort=supplierName,asc&page=0&size=20`

Customers
- Segment OR + city filter:
  - GET `/api/v1/customers?segment=SME&segment=CORPORATE&city=Ankara&sort=customerName,desc&page=0&size=20`

### Backward/forward compatibility
- Path params standardized: `{supplierId}`, `{customerId}`; clients should update if previously using `{id}`.
- UoM no longer hard-enforced by OpenAPI enum; prevents client-side breakage while keeping server validation intact.
- Sort direction is more permissive (case-insensitive), no breaks expected.

### Implementation notes
- UoM allowed values in descriptions match DB CHECK and include diacritics (`çuval`, `şişe`).
- Unknown parameter handling and filter validation are documented; ensure backend enforces 400 on unknown/invalid params.
- Reusable components retained for common params; resource-specific filters documented inline for clarity.