### PR TITLE
refactor(scripts): organize development scripts into boot subfolder

### DIFF
--- a/scripts/boot/devdown.bat
+++ b/scripts/boot/devdown.bat
@@ -6,6 +6,6 @@ REM This script stops and removes all containers from the development environmen
 REM It will cleanly shut down PostgreSQL database, pgAdmin, and remove the 
 REM associated Docker network to free up system resources.
 REM
-REM Usage: scripts\devdown.bat
+REM Usage: scripts\boot\devdown.bat
 REM
 docker compose -f docker-compose.dev.yml down

--- a/scripts/boot/devdown.sh
+++ b/scripts/boot/devdown.sh
@@ -6,6 +6,6 @@
 # It will cleanly shut down PostgreSQL database, pgAdmin, and remove the 
 # associated Docker network to free up system resources.
 #
-# Usage: ./scripts/devdown.sh
+# Usage: ./scripts/boot/devdown.sh
 #
 docker compose -f docker-compose.dev.yml down

--- a/scripts/boot/devup.bat
+++ b/scripts/boot/devup.bat
@@ -6,6 +6,6 @@ REM This script starts the development environment using Docker Compose.
 REM It will start all required services (PostgreSQL database, pgAdmin) 
 REM in detached mode, allowing you to continue working in the command prompt.
 REM
-REM Usage: scripts\devup.bat
+REM Usage: scripts\boot\devup.bat
 REM
 docker compose -f docker-compose.dev.yml up -d

--- a/scripts/boot/devup.sh
+++ b/scripts/boot/devup.sh
@@ -6,6 +6,6 @@
 # It will start all required services (PostgreSQL database, pgAdmin) 
 # in detached mode, allowing you to continue working in the terminal.
 #
-# Usage: ./scripts/devup.sh
+# Usage: ./scripts/boot/devup.sh
 #
 docker compose -f docker-compose.dev.yml up -d


### PR DESCRIPTION
### What does this PR do?
This PR reorganizes the development scripts by moving them from the root `scripts/` folder into a `scripts/boot/` subfolder for better project structure and organization.

### Why is this change needed?
- **Better Organization**: Groups related development utilities together
- **Cleaner Structure**: Reduces clutter in the main scripts directory
- **Scalability**: Makes room for other script categories in the future

### What changed?
- Moved `devup.sh`, `devup.bat`, `devdown.sh`, `devdown.bat` to `scripts/boot/`
- No functional changes - scripts work exactly the same