### PR TITLE
refactor(campaigns-db,api): remove minQty from campaigns; align sales…

### DIFF
--- a/services/inventory/src/main/resources/db/migration/V4__campaign_tables.sql
+++ b/services/inventory/src/main/resources/db/migration/V4__campaign_tables.sql
@@ -19,7 +19,6 @@ CREATE TABLE IF NOT EXISTS campaigns (
   -- Type parameters (nullable depending on type)
   discount_percentage        NUMERIC(5,2)
                   CHECK (discount_percentage IS NULL OR (discount_percentage >= 0 AND discount_percentage <= 100)),
-  min_qty INTEGER CHECK (min_qty IS NULL OR min_qty > 0),
   buy_qty        INTEGER CHECK (buy_qty IS NULL OR buy_qty > 0),
   get_qty        INTEGER CHECK (get_qty IS NULL OR get_qty > 0),
 
@@ -47,7 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_campaigns_window ON campaigns (start_date, end_da
 CREATE INDEX IF NOT EXISTS idx_campaigns_type   ON campaigns (campaign_type);
 
 COMMENT ON TABLE campaigns IS
-  'Product-scoped promos. Types: DISCOUNT (percent[, min_qty]), BXGY_SAME_PRODUCT (buy_qty, get_qty[, min_qty]). Dates inclusive.';
+  'Product-scoped promos. Types: DISCOUNT (percent), BXGY_SAME_PRODUCT (buy_qty, get_qty). Dates inclusive.';
 
 -- --------------------------------------------
 -- 1b) Campaign → Products assignment (many-to-many)

--- a/services/inventory/src/main/resources/db/migration/V6__sales_tables.sql
+++ b/services/inventory/src/main/resources/db/migration/V6__sales_tables.sql
@@ -15,14 +15,11 @@
 --
 --  1) Product campaign percent (productPct) for a line (productId, qty):
 --     • No active campaign on order_date                -> productPct = 0
---     • Type = 'DISCOUNT':
---           if (min_qty IS NULL OR qty >= min_qty)      productPct = discount_percentage
---           else                                        productPct = 0
+--     • Type = 'DISCOUNT':                              productPct = discount_percentage (no min-qty gate in PoC)
 --     • Type = 'BXGY_SAME_PRODUCT' (countable UoMs only: adet, koli, paket, çuval, şişe):
 --           group = buy_qty + get_qty
 --           free  = floor(qty / group) * get_qty
 --           productPct = round( (free::numeric / qty) * 100, 2 )
---           (Optionally: if qty < min_qty then productPct = 0)
 --
 --  2) Customer offer percent (customerPct) from header snapshot:
 --     • If one active offer exists on order_date        -> customerPct = percent_off

--- a/shared/api-contracts/openapi/inventory-service-openapi-v1.yaml
+++ b/shared/api-contracts/openapi/inventory-service-openapi-v1.yaml
@@ -948,7 +948,6 @@ components:
         campaignName: {type: string}
         campaignType: {$ref: '#/components/schemas/CampaignType'}
         discountPercentage: {type: number, format: double, minimum: 0, maximum: 100, nullable: true}
-        minQty: {type: integer, minimum: 1, nullable: true}
         buyQty: {type: integer, minimum: 1, nullable: true}
         getQty: {type: integer, minimum: 1, nullable: true}
         startDate: {type: string, format: date}
@@ -964,7 +963,6 @@ components:
         campaignType:
           $ref: '#/components/schemas/CampaignType'
         discountPercentage: {type: number, format: double, minimum: 0, maximum: 100}
-        minQty: {type: integer, minimum: 1, nullable: true}
         startDate: {type: string, format: date}
         endDate: {type: string, format: date}
 
@@ -977,7 +975,6 @@ components:
           $ref: '#/components/schemas/CampaignType'
         buyQty: {type: integer, minimum: 1}
         getQty: {type: integer, minimum: 1}
-        minQty: {type: integer, minimum: 1, nullable: true}
         startDate: {type: string, format: date}
         endDate: {type: string, format: date}
 


### PR DESCRIPTION
### What does this PR do?
Removes `min_qty` from campaigns and aligns sales logic; syncs OpenAPI accordingly.

### Why?
- Simplify PoC rules (no min-qty gating for discounts)
- Keep DB, service logic, and OpenAPI consistent

### Changes
- V4: drop `min_qty`; update table comment
- V6: remove min-qty gating in sales discount comments
- OpenAPI: remove `minQty` from `Campaign`, `CampaignCreateDiscount`, `CampaignCreateBxgy`

### How to test
- Run migrations against a fresh DB
- Verify sales order pricing logic still applies percent discounts without min-qty
- Validate OpenAPI schema builds with removed fields

### Scope/Impact
- Backward-compatible for PoC; no runtime behavior change beyond removing min-qty rule in docs/comments only