### PR TITLE
feat(ui): add order list page with editor, filters, and CRUD

### DIFF
--- a/services/frontend/src/app/app.routes.ts
+++ b/services/frontend/src/app/app.routes.ts
@@ -2,11 +2,13 @@ import { Routes } from '@angular/router';
 import { ProductPageComponent } from './pages/product-page/product-page';
 import { SupplierPageComponent } from './pages/supplier-page/supplier-page';
 import { CustomerPageComponent } from './pages/customer-page/customer-page';
+import { OrderPageComponent } from './pages/order-page/order-page';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'products', pathMatch: 'full' },
   { path: 'products', component: ProductPageComponent },
   { path: 'suppliers', component: SupplierPageComponent },
   { path: 'customers', component: CustomerPageComponent },
+  { path: 'orders', component: OrderPageComponent },
   { path: '**', redirectTo: 'products' } // This must be last
 ];

--- a/services/frontend/src/app/models/order.model.ts
+++ b/services/frontend/src/app/models/order.model.ts
@@ -1,0 +1,66 @@
+// order.model.ts
+export type OrderType = 'purchase' | 'sales';
+
+export type PurchaseOrderStatus = 'placed' | 'in_transit' | 'received' | 'canceled';
+export type SalesOrderStatus = 'pending' | 'allocated' | 'in_transit' | 'delivered' | 'canceled';
+
+export interface Order {
+  id: string;
+  type: OrderType;
+  supplierId?: string; // for purchase orders
+  customerId?: string; // for sales orders
+  orderDate: string;
+  deliveryDate?: string;
+  quantity: number;
+  totalPrice: number;
+  status: PurchaseOrderStatus | SalesOrderStatus;
+  selected?: boolean;
+  
+  // Additional fields
+  productId?: string;
+  notes?: string;
+}
+
+export interface OrderItem {
+  id: string;
+  orderId: string;
+  productId: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+}
+
+// Type guards
+export function isPurchaseOrder(order: Order): order is Order & { status: PurchaseOrderStatus } {
+  return order.type === 'purchase';
+}
+
+export function isSalesOrder(order: Order): order is Order & { status: SalesOrderStatus } {
+  return order.type === 'sales';
+}
+
+// Status progression helpers
+export const PURCHASE_STATUS_ORDER: PurchaseOrderStatus[] = ['placed', 'in_transit', 'received', 'canceled'];
+export const SALES_STATUS_ORDER: SalesOrderStatus[] = ['pending', 'allocated', 'in_transit', 'delivered', 'canceled'];
+
+export function getStatusColor(status: PurchaseOrderStatus | SalesOrderStatus): string {
+  if (status === 'canceled') {
+    return '#d64545'; // red
+  }
+  
+  const statusOrder = PURCHASE_STATUS_ORDER.includes(status as PurchaseOrderStatus) 
+    ? PURCHASE_STATUS_ORDER 
+    : SALES_STATUS_ORDER;
+  
+  const index = statusOrder.indexOf(status as any);
+  const total = statusOrder.length - 1; // exclude 'canceled'
+  
+  if (index === -1 || index === total) return '#d64545'; // canceled or not found
+  
+  // Interpolate from blue to green
+  const ratio = index / (total - 1);
+  const blue = Math.round(255 * (1 - ratio));
+  const green = Math.round(255 * ratio);
+  
+  return `rgb(${Math.round(blue * 0.2)}, ${green}, ${Math.round(blue * 0.8)})`;
+}

--- a/services/frontend/src/app/orders/order-editor/order-editor.html
+++ b/services/frontend/src/app/orders/order-editor/order-editor.html
@@ -1,0 +1,140 @@
+<!-- order-editor.html -->
+<div class="backdrop" (click)="close.emit()"></div>
+
+<section class="modal" role="dialog" aria-modal="true" (click)="$event.stopPropagation()">
+  <button class="close" aria-label="Close" (click)="close.emit()">✕</button>
+  
+  <form [formGroup]="form" (ngSubmit)="onSave()">
+    <div class="grid">
+      <!-- Header Section -->
+      <div class="row1">
+        <label class="box">
+          <span class="label">ORDER ID</span>
+          <input type="text" class="input" formControlName="id" [readonly]="!isNewOrder">
+        </label>
+        
+        <label class="box">
+          <span class="label">ORDER TYPE</span>
+          <select class="input" formControlName="type" (change)="onTypeChange()" [disabled]="!isNewOrder">
+            <option value="purchase">Purchase Order</option>
+            <option value="sales">Sales Order</option>
+          </select>
+        </label>
+      </div>
+
+      <!-- Product and Supplier/Customer Section -->
+      <div class="row2">
+        <label class="box">
+          <span class="label">PRODUCT</span>
+          <select class="input" formControlName="productId">
+            <option value="">Select Product</option>
+            <option *ngFor="let product of products" [value]="product.id">
+              {{ product.name }} ({{ product.id }})
+            </option>
+          </select>
+        </label>
+        
+        <label class="box" *ngIf="isPurchaseOrder">
+          <span class="label">SUPPLIER</span>
+          <select class="input" formControlName="supplierId">
+            <option value="">Select Supplier</option>
+            <option *ngFor="let supplier of suppliers" [value]="supplier.id">
+              {{ supplier.name }}
+            </option>
+          </select>
+        </label>
+        
+        <label class="box" *ngIf="!isPurchaseOrder">
+          <span class="label">CUSTOMER</span>
+          <select class="input" formControlName="customerId">
+            <option value="">Select Customer</option>
+            <option *ngFor="let customer of customers" [value]="customer.id">
+              {{ customer.name }}
+            </option>
+          </select>
+        </label>
+      </div>
+
+      <!-- Date Section with Dropdown -->
+      <div class="row3">
+        <div class="box date-picker">
+          <span class="label">ORDER DATE</span>
+          <button type="button" class="date-button" (click)="toggleOrderDatePicker()">
+            {{ formatDateDisplay(form.value.orderDate || '') }}
+            <span class="dropdown-arrow">▼</span>
+          </button>
+          <div class="date-dropdown" *ngIf="orderDateOpen">
+            <div class="date-options">
+              <button 
+                type="button" 
+                class="date-option"
+                *ngFor="let date of generateDateOptions()" 
+                [class.selected]="form.value.orderDate === date"
+                (click)="setOrderDate(date)">
+                {{ formatDateDisplay(date) }}
+              </button>
+            </div>
+          </div>
+        </div>
+        
+        <div class="box date-picker">
+          <span class="label">DELIVERY DATE</span>
+          <button type="button" class="date-button" (click)="toggleDeliveryDatePicker()">
+            {{ formatDateDisplay(form.value.deliveryDate || '') }}
+            <span class="dropdown-arrow">▼</span>
+          </button>
+          <div class="date-dropdown" *ngIf="deliveryDateOpen">
+            <div class="date-options">
+              <button 
+                type="button" 
+                class="date-option"
+                *ngFor="let date of generateDateOptions()" 
+                [class.selected]="form.value.deliveryDate === date"
+                (click)="setDeliveryDate(date)">
+                {{ formatDateDisplay(date) }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Quantity, Price, Status Section -->
+      <div class="sidebar">
+        <label class="box">
+          <span class="label">QUANTITY</span>
+          <input type="number" class="input" formControlName="quantity" min="1">
+        </label>
+        
+        <label class="box">
+          <span class="label">TOTAL PRICE</span>
+          <input type="number" class="input" formControlName="totalPrice" min="0" step="0.01">
+        </label>
+        
+        <label class="box">
+          <span class="label">STATUS</span>
+          <select class="input" formControlName="status">
+            <option *ngFor="let status of currentStatuses" [value]="status">
+              {{ status.replace('_', ' ') | titlecase }}
+            </option>
+          </select>
+        </label>
+      </div>
+
+      <!-- Notes Section -->
+      <label class="box big">
+        <span class="label">NOTES</span>
+        <textarea class="textarea" formControlName="notes" placeholder="Optional notes about this order..."></textarea>
+      </label>
+
+      <!-- Actions -->
+      <div class="actions">
+        <button class="btn primary" type="submit" [disabled]="form.invalid">
+          SAVE ORDER
+        </button>
+        <button class="btn danger" type="button" (click)="onDelete()" [disabled]="isNewOrder">
+          DELETE ORDER
+        </button>
+      </div>
+    </div>
+  </form>
+</section>

--- a/services/frontend/src/app/orders/order-editor/order-editor.scss
+++ b/services/frontend/src/app/orders/order-editor/order-editor.scss
@@ -1,0 +1,233 @@
+/* order-editor.scss */
+:host { 
+  position: fixed; 
+  inset: 0; 
+  display: grid; 
+  place-items: center; 
+  z-index: 1000; 
+}
+
+.backdrop { 
+  position: absolute; 
+  inset: 0; 
+  background: rgba(0,0,0,.35); 
+}
+
+.modal {
+  position: relative;
+  width: min(1080px, 96vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 10px 40px rgba(0,0,0,.25);
+  padding: 24px 24px 18px;
+  border: 3px solid #163a5a;
+}
+
+.close {
+  position: absolute; 
+  top: 10px; 
+  right: 12px;
+  background: transparent; 
+  border: 0; 
+  font-size: 22px; 
+  cursor: pointer; 
+  color: #163a5a;
+}
+
+.grid { 
+  display: grid; 
+  grid-template-columns: 1fr; 
+  gap: 16px; 
+}
+
+.row1, .row2, .row3 { 
+  display: grid; 
+  grid-template-columns: 1fr 1fr; 
+  gap: 20px; 
+  width: calc(100% - 300px);
+}
+
+.box {
+  border: 3px solid #163a5a; 
+  border-radius: 4px; 
+  background: #d4d6d7; 
+  padding: 8px;
+  display: grid; 
+  gap: 6px;
+  position: relative;
+}
+
+.box.big { 
+  height: 120px;
+  width: calc(100% - 300px);
+}
+
+.date-picker {
+  position: relative;
+}
+
+.label { 
+  font-weight: 700; 
+  color: #163a5a; 
+  font-size: 14px; 
+}
+
+.input, .date-button { 
+  width: 100%; 
+  border: 0; 
+  outline: none; 
+  background: transparent; 
+  font-size: 16px; 
+  padding: 4px 0;
+}
+
+.date-button {
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: inherit;
+  color: inherit;
+}
+
+.dropdown-arrow {
+  font-size: 12px;
+  color: #163a5a;
+}
+
+.date-dropdown {
+  position: absolute;
+  top: 100%;
+  left: -3px;
+  right: -3px;
+  background: white;
+  border: 3px solid #163a5a;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  z-index: 1001;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.date-options {
+  display: flex;
+  flex-direction: column;
+}
+
+.date-option {
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #e0e0e0;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease;
+}
+
+.date-option:hover {
+  background: #f0f0f0;
+}
+
+.date-option.selected {
+  background: #163a5a;
+  color: white;
+}
+
+.date-option:last-child {
+  border-bottom: none;
+}
+
+.textarea { 
+  width: 100%; 
+  height: 100%; 
+  resize: none; 
+  border: 0; 
+  outline: none; 
+  background: transparent; 
+  font-size: 16px; 
+  line-height: 1.4; 
+}
+
+select.input {
+  cursor: pointer;
+}
+
+.sidebar {
+  position: absolute; 
+  top: 50px; 
+  right: 24px; 
+  width: 260px;
+  display: grid; 
+  gap: 16px;
+}
+
+@media (max-width: 1000px) {
+  .sidebar { 
+    position: static; 
+    width: 100%; 
+  }
+  .row1, .row2, .row3, .box.big { 
+    width: 100%; 
+  }
+}
+
+.actions { 
+  margin-top: 14px; 
+  display: flex; 
+  gap: 16px; 
+  justify-content: flex-end; 
+}
+
+.btn { 
+  border: 0; 
+  border-radius: 10px; 
+  padding: 12px 28px; 
+  font-weight: 700; 
+  cursor: pointer; 
+  transition: all 0.2s ease;
+}
+
+.btn.primary { 
+  background: #123a8a; 
+  color: #fff; 
+}
+
+.btn.primary:hover {
+  background: #0f2f75;
+}
+
+.btn.danger { 
+  background: #8e1c28; 
+  color: #fff; 
+}
+
+.btn.danger:hover {
+  background: #7a1822;
+}
+
+.btn:disabled { 
+  opacity: .6; 
+  cursor: not-allowed; 
+}
+
+/* Custom scrollbar for date dropdown */
+.date-dropdown::-webkit-scrollbar {
+  width: 6px;
+}
+
+.date-dropdown::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.date-dropdown::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 3px;
+}
+
+.date-dropdown::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}

--- a/services/frontend/src/app/orders/order-editor/order-editor.spec.ts
+++ b/services/frontend/src/app/orders/order-editor/order-editor.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrderEditor } from './order-editor';
+
+describe('OrderEditor', () => {
+  let component: OrderEditor;
+  let fixture: ComponentFixture<OrderEditor>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OrderEditor]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OrderEditor);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/services/frontend/src/app/orders/order-editor/order-editor.ts
+++ b/services/frontend/src/app/orders/order-editor/order-editor.ts
@@ -1,0 +1,169 @@
+// order-editor.ts
+import { Component, EventEmitter, Input, Output, inject, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { Order, OrderType, PurchaseOrderStatus, SalesOrderStatus, isPurchaseOrder } from '../../models/order.model';
+import { Supplier } from '../../models/supplier.model';
+import { Customer } from '../../models/customer.model';
+import { Product } from '../../models/product.model';
+
+@Component({
+  selector: 'app-order-editor',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './order-editor.html',
+  styleUrls: ['./order-editor.scss'],
+})
+export class OrderEditorComponent implements OnChanges {
+  @Input() value: Order | null = null;
+  @Input() suppliers: Supplier[] = [];
+  @Input() customers: Customer[] = [];
+  @Input() products: Product[] = [];
+
+  @Output() close = new EventEmitter<void>();
+  @Output() save = new EventEmitter<Order>();
+  @Output() delete = new EventEmitter<string>();
+
+  private fb = inject(FormBuilder);
+
+  form = this.fb.group({
+    id: [''],
+    type: ['purchase' as OrderType, Validators.required],
+    supplierId: [''],
+    customerId: [''],
+    productId: [''],
+    orderDate: ['', Validators.required],
+    deliveryDate: [''],
+    quantity: [0, [Validators.required, Validators.min(1)]],
+    totalPrice: [0, [Validators.required, Validators.min(0)]],
+    status: ['placed' as PurchaseOrderStatus | SalesOrderStatus, Validators.required],
+    notes: ['']
+  });
+
+  // Track if order date picker is open
+  orderDateOpen = false;
+  deliveryDateOpen = false;
+
+  ngOnChanges() {
+    if (this.value) {
+      this.form.patchValue({
+        id: this.value.id || '',
+        type: this.value.type,
+        supplierId: this.value.supplierId || '',
+        customerId: this.value.customerId || '',
+        productId: this.value.productId || '',
+        orderDate: this.value.orderDate,
+        deliveryDate: this.value.deliveryDate || '',
+        quantity: this.value.quantity,
+        totalPrice: this.value.totalPrice,
+        status: this.value.status,
+        notes: this.value.notes || ''
+      });
+    }
+  }
+
+  get isNewOrder(): boolean {
+    return !this.value?.id;
+  }
+
+  get isPurchaseOrder(): boolean {
+    return this.form.value.type === 'purchase';
+  }
+
+  get purchaseStatuses(): PurchaseOrderStatus[] {
+    return ['placed', 'in_transit', 'received', 'canceled'];
+  }
+
+  get salesStatuses(): SalesOrderStatus[] {
+    return ['pending', 'allocated', 'in_transit', 'delivered', 'canceled'];
+  }
+
+  get currentStatuses(): (PurchaseOrderStatus | SalesOrderStatus)[] {
+    return this.isPurchaseOrder ? this.purchaseStatuses : this.salesStatuses;
+  }
+
+  onTypeChange() {
+    // Reset supplier/customer when type changes
+    this.form.patchValue({
+      supplierId: '',
+      customerId: '',
+      status: this.isPurchaseOrder ? 'placed' : 'pending'
+    });
+  }
+
+  onSave() {
+    if (!this.form.valid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.form.getRawValue();
+    const out: Order = {
+      ...(this.value ?? {}),
+      id: raw.id ?? '',
+      type: raw.type!,
+      supplierId: raw.type === 'purchase' ? raw.supplierId || undefined : undefined,
+      customerId: raw.type === 'sales' ? raw.customerId || undefined : undefined,
+      productId: raw.productId || undefined,
+      orderDate: raw.orderDate!,
+      deliveryDate: raw.deliveryDate || undefined,
+      quantity: raw.quantity!,
+      totalPrice: raw.totalPrice!,
+      status: raw.status!,
+      notes: raw.notes || undefined
+    };
+
+    this.save.emit(out);
+  }
+
+  onDelete() {
+    if (this.value?.id) {
+      this.delete.emit(this.value.id);
+    }
+  }
+
+  toggleOrderDatePicker() {
+    this.orderDateOpen = !this.orderDateOpen;
+    this.deliveryDateOpen = false;
+  }
+
+  toggleDeliveryDatePicker() {
+    this.deliveryDateOpen = !this.deliveryDateOpen;
+    this.orderDateOpen = false;
+  }
+
+  setOrderDate(date: string) {
+    this.form.patchValue({ orderDate: date });
+    this.orderDateOpen = false;
+  }
+
+  setDeliveryDate(date: string) {
+    this.form.patchValue({ deliveryDate: date });
+    this.deliveryDateOpen = false;
+  }
+
+  generateDateOptions(): string[] {
+    const dates = [];
+    const today = new Date();
+    
+    // Generate dates from 30 days ago to 60 days in the future
+    for (let i = -30; i <= 60; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() + i);
+      dates.push(date.toISOString().split('T')[0]);
+    }
+    
+    return dates;
+  }
+
+  formatDateDisplay(dateString: string): string {
+    if (!dateString) return 'Select date';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  }
+}

--- a/services/frontend/src/app/orders/order-listing/order-listing.html
+++ b/services/frontend/src/app/orders/order-listing/order-listing.html
@@ -1,0 +1,34 @@
+<!-- order-listing.html -->
+<section class="list-wrapper">
+  <table>
+    <thead>
+      <tr>
+        <th class="chk">
+          <input type="checkbox"
+                 [checked]="allSelected"
+                 (change)="toggleAll($any($event.target).checked)" />
+        </th>
+        <th>TYPE</th>
+        <th>ID</th>
+        <th>SUPPLIER/CUSTOMER</th>
+        <th>ORDER DATE</th>
+        <th>DELIVERY DATE</th>
+        <th>QUANTITY</th>
+        <th>TOTAL PRICE</th>
+        <th class="status">STATUS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <app-order
+        *ngFor="let order of orders"
+        [order]="order"
+        [suppliers]="suppliers"
+        [customers]="customers"
+        [products]="products"
+        (rowClick)="edit.emit($event)"
+        (toggle)="selectionChange.emit()"
+        (statusChange)="statusChange.emit($event)">
+      </app-order>
+    </tbody>
+  </table>
+</section>

--- a/services/frontend/src/app/orders/order-listing/order-listing.scss
+++ b/services/frontend/src/app/orders/order-listing/order-listing.scss
@@ -1,0 +1,33 @@
+/* order-listing.scss */
+.list-wrapper {
+  background: #f7f9fc;
+  border-radius: 10px;
+  overflow: hidden;
+  margin: .75rem 1.5rem 1.5rem;
+  border: 1px solid #e3e8ef;
+}
+
+table { 
+  width: 100%; 
+  border-collapse: collapse; 
+  background: #f1f3f6; 
+}
+
+thead th {
+  text-align: left;
+  padding: .85rem .8rem;
+  background: #c9cdd3;
+  color: #222;
+  font-weight: 700;
+  letter-spacing: .02em;
+  font-size: .88rem;
+}
+
+thead th.chk { 
+  width: 42px; 
+}
+
+thead th.status { 
+  width: 100px; 
+  text-align: center; 
+}

--- a/services/frontend/src/app/orders/order-listing/order-listing.spec.ts
+++ b/services/frontend/src/app/orders/order-listing/order-listing.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrderListing } from './order-listing';
+
+describe('OrderListing', () => {
+  let component: OrderListing;
+  let fixture: ComponentFixture<OrderListing>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OrderListing]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OrderListing);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/services/frontend/src/app/orders/order-listing/order-listing.ts
+++ b/services/frontend/src/app/orders/order-listing/order-listing.ts
@@ -1,0 +1,33 @@
+// order-listing.ts
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Order, PurchaseOrderStatus, SalesOrderStatus } from '../../models/order.model';
+import { Supplier } from '../../models/supplier.model';
+import { Customer } from '../../models/customer.model';
+import { Product } from '../../models/product.model';
+import { OrderComponent } from '../order/order';
+
+@Component({
+  selector: 'app-order-listing',
+  standalone: true,
+  imports: [CommonModule, OrderComponent],
+  templateUrl: './order-listing.html',
+  styleUrls: ['./order-listing.scss']
+})
+export class OrderListingComponent {
+  @Input({ required: true }) orders: Order[] = [];
+  @Input({ required: true }) suppliers: Supplier[] = [];
+  @Input({ required: true }) customers: Customer[] = [];
+  @Input({ required: true }) products: Product[] = [];
+  @Output() edit = new EventEmitter<Order>();
+  @Output() selectionChange = new EventEmitter<void>();
+  @Output() statusChange = new EventEmitter<{ order: Order, newStatus: PurchaseOrderStatus | SalesOrderStatus }>();
+
+  allSelected = false;
+
+  toggleAll(checked: boolean) {
+    this.allSelected = checked;
+    for (const o of this.orders) o.selected = checked;
+    this.selectionChange.emit();
+  }
+}

--- a/services/frontend/src/app/orders/order/order.html
+++ b/services/frontend/src/app/orders/order/order.html
@@ -1,0 +1,26 @@
+<!-- order-row.html -->
+<tr [class.canceled]="order.status === 'canceled'" (click)="rowClick.emit(order)">
+  <td class="chk">
+    <input type="checkbox"
+           [(ngModel)]="order.selected"
+           (change)="toggle.emit(!!order.selected)"
+           (click)="$event.stopPropagation()" />
+  </td>
+  <td class="type">
+    <span class="type-badge" [ngClass]="typeClass">{{ typeDisplay }}</span>
+  </td>
+  <td class="order-id">{{ order.id }}</td>
+  <td class="supplier-customer">{{ supplierCustomerDisplay }}</td>
+  <td class="date">{{ formattedOrderDate }}</td>
+  <td class="date">{{ formattedDeliveryDate }}</td>
+  <td class="quantity">{{ order.quantity | number }}</td>
+  <td class="price">{{ formattedTotalPrice }}</td>
+  <td class="status">
+    <span class="status-dot clickable" 
+          [style.background-color]="statusColor"
+          [title]="'Click to change status (currently: ' + statusLabel + ')'"
+          (click)="onStatusClick($event)">
+    </span>
+    <span class="status-label">{{ statusLabel }}</span>
+  </td>
+</tr>

--- a/services/frontend/src/app/orders/order/order.scss
+++ b/services/frontend/src/app/orders/order/order.scss
@@ -1,0 +1,126 @@
+/* order-row.scss */
+:host { 
+  display: contents; 
+}
+
+tr {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+tr:hover {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+tr.canceled { 
+  background: #fef2f2; 
+  opacity: 0.8;
+}
+
+td, th {
+  padding: .9rem .8rem;
+  border-bottom: 1px solid #e7ebf1;
+  font-size: .92rem;
+  color: #2a2f36;
+  vertical-align: middle;
+}
+
+td.chk { 
+  width: 42px; 
+}
+
+td.type {
+  width: 60px;
+  text-align: center;
+}
+
+.type-badge {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  color: white;
+  font-weight: bold;
+  font-size: 12px;
+  line-height: 24px;
+  text-align: center;
+  
+  &.purchase {
+    background: #ff9900;
+  }
+  
+  &.sales {
+    background: #0db257;
+  }
+}
+
+td.order-id {
+  font-family: monospace;
+  font-weight: 600;
+  min-width: 100px;
+}
+
+td.supplier-customer {
+  min-width: 180px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+td.date {
+  min-width: 100px;
+  font-size: 0.88rem;
+  color: #64748b;
+}
+
+td.quantity {
+  text-align: right;
+  font-weight: 600;
+  min-width: 80px;
+}
+
+td.price {
+  text-align: right;
+  font-weight: 600;
+  min-width: 120px;
+  color: #16a34a;
+}
+
+td.status { 
+  width: 120px; 
+  text-align: center;
+}
+
+.status-dot { 
+  width: 16px; 
+  height: 16px; 
+  border-radius: 50%; 
+  display: inline-block; 
+  margin-right: 8px;
+  transition: all 0.2s ease;
+  vertical-align: middle;
+}
+
+.status-dot.clickable {
+  cursor: pointer;
+  transform: scale(1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.status-dot.clickable:hover {
+  transform: scale(1.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.status-dot.clickable:active {
+  transform: scale(0.95);
+}
+
+.status-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+}

--- a/services/frontend/src/app/orders/order/order.spec.ts
+++ b/services/frontend/src/app/orders/order/order.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Order } from './order';
+
+describe('Order', () => {
+  let component: Order;
+  let fixture: ComponentFixture<Order>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Order]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(Order);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/services/frontend/src/app/orders/order/order.ts
+++ b/services/frontend/src/app/orders/order/order.ts
@@ -1,0 +1,96 @@
+// order-row.ts
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Order, PurchaseOrderStatus, SalesOrderStatus, isPurchaseOrder, isSalesOrder, getStatusColor, PURCHASE_STATUS_ORDER, SALES_STATUS_ORDER } from '../../models/order.model';
+import { Supplier } from '../../models/supplier.model';
+import { Customer } from '../../models/customer.model';
+import { Product } from '../../models/product.model';
+
+@Component({
+  selector: 'app-order',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './order.html',
+  styleUrls: ['./order.scss']
+})
+export class OrderComponent {
+  @Input({ required: true }) order!: Order;
+  @Input({ required: true }) suppliers: Supplier[] = [];
+  @Input({ required: true }) customers: Customer[] = [];
+  @Input({ required: true }) products: Product[] = [];
+  @Output() toggle = new EventEmitter<boolean>();
+  @Output() rowClick = new EventEmitter<Order>();
+  @Output() statusChange = new EventEmitter<{ order: Order, newStatus: PurchaseOrderStatus | SalesOrderStatus }>();
+
+  get statusColor() {
+    return getStatusColor(this.order.status);
+  }
+
+  get typeDisplay() {
+    return this.order.type === 'purchase' ? 'P' : 'S';
+  }
+
+  get typeClass() {
+    return this.order.type === 'purchase' ? 'purchase' : 'sales';
+  }
+
+  get supplierCustomerDisplay() {
+    if (this.order.type === 'purchase' && this.order.supplierId) {
+      const supplier = this.suppliers.find(s => s.id === this.order.supplierId);
+      return supplier ? supplier.name : this.order.supplierId;
+    } else if (this.order.type === 'sales' && this.order.customerId) {
+      const customer = this.customers.find(c => c.id === this.order.customerId);
+      return customer ? customer.name : this.order.customerId;
+    }
+    return '';
+  }
+
+  get formattedOrderDate() {
+    return new Date(this.order.orderDate).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  get formattedDeliveryDate() {
+    if (!this.order.deliveryDate) return '';
+    return new Date(this.order.deliveryDate).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  get formattedTotalPrice() {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(this.order.totalPrice);
+  }
+
+  get statusLabel() {
+    return this.order.status.replace('_', ' ').toUpperCase();
+  }
+
+  onStatusClick(event: Event) {
+    event.stopPropagation();
+    
+    let newStatus: PurchaseOrderStatus | SalesOrderStatus;
+    
+    if (isPurchaseOrder(this.order)) {
+      const currentIndex = PURCHASE_STATUS_ORDER.indexOf(this.order.status as PurchaseOrderStatus);
+      const nextIndex = (currentIndex + 1) % PURCHASE_STATUS_ORDER.length;
+      newStatus = PURCHASE_STATUS_ORDER[nextIndex];
+    } else if (isSalesOrder(this.order)) {
+      const currentIndex = SALES_STATUS_ORDER.indexOf(this.order.status as SalesOrderStatus);
+      const nextIndex = (currentIndex + 1) % SALES_STATUS_ORDER.length;
+      newStatus = SALES_STATUS_ORDER[nextIndex];
+    } else {
+      return;
+    }
+    
+    this.statusChange.emit({ order: this.order, newStatus });
+  }
+}

--- a/services/frontend/src/app/pages/mock-data.service.ts
+++ b/services/frontend/src/app/pages/mock-data.service.ts
@@ -2,9 +2,10 @@ import { Injectable } from '@angular/core';
 import { Product } from '../models/product.model';
 import { Supplier } from '../models/supplier.model';
 import { Customer } from '../models/customer.model';
+import { Order, OrderType, PurchaseOrderStatus, SalesOrderStatus } from '../models/order.model';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class MockDataService {
   getProducts(): Product[] {
@@ -411,6 +412,143 @@ export class MockDataService {
         email: 'jack.taylor@example.com',
         phone: '+90 510 000 11 22',
         city: 'Mersin',
+      },
+    ];
+  }
+
+  getOrders(): Order[] {
+    return [
+      {
+        id: 'PO-001',
+        type: 'purchase',
+        supplierId: 'SUP-001',
+        orderDate: '2024-09-01',
+        deliveryDate: '2024-09-15',
+        quantity: 500,
+        totalPrice: 25000,
+        status: 'received',
+        productId: 'ID-001',
+      },
+      {
+        id: 'PO-002',
+        type: 'purchase',
+        supplierId: 'SUP-002',
+        orderDate: '2024-09-03',
+        deliveryDate: '2024-09-20',
+        quantity: 100,
+        totalPrice: 8500,
+        status: 'in_transit',
+        productId: 'ID-002',
+      },
+      {
+        id: 'PO-003',
+        type: 'purchase',
+        supplierId: 'SUP-003',
+        orderDate: '2024-09-05',
+        deliveryDate: '2024-09-25',
+        quantity: 200,
+        totalPrice: 15000,
+        status: 'placed',
+        productId: 'ID-003',
+      },
+      {
+        id: 'PO-004',
+        type: 'purchase',
+        supplierId: 'SUP-004',
+        orderDate: '2024-08-28',
+        deliveryDate: '2024-09-10',
+        quantity: 50,
+        totalPrice: 3200,
+        status: 'canceled',
+        productId: 'ID-004',
+      },
+      {
+        id: 'SO-001',
+        type: 'sales',
+        customerId: 'CUST-001',
+        orderDate: '2024-09-02',
+        deliveryDate: '2024-09-16',
+        quantity: 10,
+        totalPrice: 2500,
+        status: 'delivered',
+        productId: 'ID-012',
+      },
+      {
+        id: 'SO-002',
+        type: 'sales',
+        customerId: 'CUST-002',
+        orderDate: '2024-09-04',
+        deliveryDate: '2024-09-18',
+        quantity: 5,
+        totalPrice: 4500,
+        status: 'in_transit',
+        productId: 'ID-016',
+      },
+      {
+        id: 'SO-003',
+        type: 'sales',
+        customerId: 'CUST-003',
+        orderDate: '2024-09-06',
+        deliveryDate: '2024-09-22',
+        quantity: 20,
+        totalPrice: 3000,
+        status: 'allocated',
+        productId: 'ID-014',
+      },
+      {
+        id: 'SO-004',
+        type: 'sales',
+        customerId: 'CUST-004',
+        orderDate: '2024-09-07',
+        deliveryDate: '2024-09-25',
+        quantity: 2,
+        totalPrice: 800,
+        status: 'pending',
+        productId: 'ID-017',
+      },
+      {
+        id: 'SO-005',
+        type: 'sales',
+        customerId: 'CUST-005',
+        orderDate: '2024-08-30',
+        deliveryDate: '2024-09-12',
+        quantity: 15,
+        totalPrice: 1800,
+        status: 'canceled',
+        productId: 'ID-018',
+      },
+      {
+        id: 'PO-005',
+        type: 'purchase',
+        supplierId: 'SUP-008',
+        orderDate: '2024-09-08',
+        deliveryDate: '2024-09-28',
+        quantity: 1000,
+        totalPrice: 75000,
+        status: 'placed',
+        productId: 'ID-001',
+      },
+      {
+        id: 'SO-006',
+        type: 'sales',
+        customerId: 'CUST-006',
+        orderDate: '2024-09-08',
+        deliveryDate: '2024-09-24',
+        quantity: 3,
+        totalPrice: 1200,
+        status: 'pending',
+        productId: 'ID-021',
+      },
+      {
+        id: 'PO-006',
+        type: 'purchase',
+        supplierId: 'SUP-013',
+        orderDate: '2024-09-09',
+        deliveryDate: '2024-09-30',
+        quantity: 500,
+        totalPrice: 12500,
+        status: 'placed',
+        productId: 'ID-013',
       },
     ];
   }

--- a/services/frontend/src/app/pages/order-page/order-page.html
+++ b/services/frontend/src/app/pages/order-page/order-page.html
@@ -1,0 +1,47 @@
+<div class="layout">
+  <app-side-nav />
+
+  <main class="content">
+    <app-header
+      title="Orders"
+      [query]="query()"
+      [deletableCount]="selectedCount()"
+      [filterOpen]="filterOpen()"
+      [typeFilter]="typeFilter()"
+      [orderStatusFilter]="statusFilter()"
+      [showFilters]="true"
+      [showAddButton]="false"
+      [customActionButtons]="getCustomActionButtons()"
+      (queryChange)="query.set($event)"
+      (clearSearch)="onClear()"
+      (deleteSelected)="deleteSelected()"
+      (openFilters)="onOpenFilters()"
+      (typeFilterSelect)="onTypeFilterSelect($event)"
+      (statusFilterSelect)="onStatusFilterSelect($event)"
+      (customAction)="onCustomAction($event)">
+    </app-header>
+
+    <div class="order-content">
+      <app-order-listing
+        [orders]="orders()"
+        [suppliers]="suppliers()"
+        [customers]="customers()"
+        [products]="products()"
+        (edit)="openEditorFor($event)"
+        (selectionChange)="bumpSelection()"
+        (statusChange)="onStatusChange($event)">
+      </app-order-listing>
+    </div>
+  </main>
+</div>
+
+<app-order-editor
+  *ngIf="editorOpen()"
+  [value]="editing()"
+  [suppliers]="suppliers()"
+  [customers]="customers()"
+  [products]="products()"
+  (close)="closeEditor()"
+  (save)="handleSave($event)"
+  (delete)="handleDelete($event)">
+</app-order-editor>

--- a/services/frontend/src/app/pages/order-page/order-page.scss
+++ b/services/frontend/src/app/pages/order-page/order-page.scss
@@ -1,0 +1,85 @@
+.layout { 
+  display: grid; 
+  grid-template-columns: 72px 1fr; 
+  min-height: 100dvh; 
+}
+
+.content { 
+  display: grid; 
+  grid-template-rows: auto 1fr; 
+  background: #fafbfd; 
+}
+
+// Ensure proper overflow handling for the order content area
+.order-content {
+  overflow: auto;
+  min-height: 0;
+}
+
+// Fix any global button styling conflicts
+button {
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.primary {
+  background: #2563eb !important;
+  color: #fff !important;
+  border: 1px solid #2563eb !important;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #1d4ed8 !important;
+    border-color: #1d4ed8 !important;
+  }
+}
+
+.danger {
+  background: #fee2e2 !important;
+  color: #dc2626 !important;
+  border: 1px solid #fecaca !important;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: #fecaca !important;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.filter {
+  background: #f3f4f6 !important;
+  color: #374151 !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #e5e7eb !important;
+  }
+}
+
+// Ensure search input styling is consistent
+.search {
+  input {
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/services/frontend/src/app/pages/order-page/order-page.spec.ts
+++ b/services/frontend/src/app/pages/order-page/order-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrderPage } from './order-page';
+
+describe('OrderPage', () => {
+  let component: OrderPage;
+  let fixture: ComponentFixture<OrderPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OrderPage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OrderPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/services/frontend/src/app/pages/order-page/order-page.ts
+++ b/services/frontend/src/app/pages/order-page/order-page.ts
@@ -1,0 +1,233 @@
+// order-page.ts
+import { Component, computed, signal, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Header } from '../../shared/header/header';
+import { SideNav } from '../../shared/side-nav/side-nav';
+import { OrderListingComponent } from '../../orders/order-listing/order-listing';
+import { OrderEditorComponent } from '../../orders/order-editor/order-editor';
+import { Order, OrderType, PurchaseOrderStatus, SalesOrderStatus } from '../../models/order.model';
+import { Supplier } from '../../models/supplier.model';
+import { Customer } from '../../models/customer.model';
+import { Product } from '../../models/product.model';
+import { MockDataService } from '../mock-data.service';
+
+@Component({
+  selector: 'app-order-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    Header,
+    SideNav,
+    OrderListingComponent,
+    OrderEditorComponent,
+  ],
+  templateUrl: './order-page.html',
+  styleUrls: ['./order-page.scss'],
+})
+export class OrderPageComponent {
+  private mockDataService = inject(MockDataService);
+
+  query = signal('');
+  editorOpen = signal(false);
+  editing = signal<Order | null>(null);
+  
+  // Filter states
+  filterOpen = signal(false);
+  typeFilter = signal<OrderType | 'all'>('all');
+  statusFilter = signal<PurchaseOrderStatus | SalesOrderStatus | 'all'>('all');
+
+  private selectionTick = signal(0);
+  
+  bumpSelection() {
+    this.selectionTick.update((n) => n + 1);
+  }
+
+  // Initialize with mock data
+  private all = signal<Order[]>(this.mockDataService.getOrders());
+  suppliers = signal<Supplier[]>(this.mockDataService.getSuppliers());
+  customers = signal<Customer[]>(this.mockDataService.getCustomers());
+  products = signal<Product[]>(this.mockDataService.getProducts());
+
+  readonly orders = computed(() => {
+    let filtered = this.all();
+    
+    // Apply type filter
+    const typeFilter = this.typeFilter();
+    if (typeFilter !== 'all') {
+      filtered = filtered.filter(o => o.type === typeFilter);
+    }
+    
+    // Apply status filter
+    const statusFilter = this.statusFilter();
+    if (statusFilter !== 'all') {
+      filtered = filtered.filter(o => o.status === statusFilter);
+    }
+    
+    // Apply search query
+    const q = this.query().trim().toLowerCase();
+    if (q) {
+      filtered = filtered.filter((o) =>
+        [
+          o.id,
+          o.supplierId,
+          o.customerId,
+          o.productId,
+          o.status,
+          o.type,
+        ].some((v) => typeof v === 'string' && v.toLowerCase().includes(q))
+      );
+    }
+    
+    return filtered;
+  });
+
+  // Depends on selectionTick so it updates when checkboxes toggle 
+  selectedCount = computed(() => {
+    this.selectionTick();
+    return this.all().filter((o) => o.selected).length;
+  });
+
+  // Status change handler
+  onStatusChange(event: { order: Order, newStatus: PurchaseOrderStatus | SalesOrderStatus }) {
+    this.all.update((list) => 
+      list.map((o) => 
+        o.id === event.order.id 
+          ? { ...o, status: event.newStatus }
+          : o
+      )
+    );
+  }
+
+  // Header event handlers
+  onAddPurchaseOrder() {
+    this.editing.set({
+      id: '',
+      type: 'purchase',
+      supplierId: '',
+      orderDate: new Date().toISOString().split('T')[0],
+      deliveryDate: '',
+      quantity: 0,
+      totalPrice: 0,
+      status: 'placed',
+      selected: false,
+    });
+    this.editorOpen.set(true);
+  }
+
+  onAddSalesOrder() {
+    this.editing.set({
+      id: '',
+      type: 'sales',
+      customerId: '',
+      orderDate: new Date().toISOString().split('T')[0],
+      deliveryDate: '',
+      quantity: 0,
+      totalPrice: 0,
+      status: 'pending',
+      selected: false,
+    });
+    this.editorOpen.set(true);
+  }
+
+  onOpenFilters() {
+    this.filterOpen.set(!this.filterOpen());
+  }
+
+  onTypeFilterSelect(type: OrderType | 'all') {
+    this.typeFilter.set(type);
+    // Reset status filter when changing type
+    this.statusFilter.set('all');
+    this.filterOpen.set(false);
+  }
+
+  onStatusFilterSelect(status: PurchaseOrderStatus | SalesOrderStatus | 'all') {
+    this.statusFilter.set(status);
+    this.filterOpen.set(false);
+  }
+
+  onCustomAction(action: string) {
+    switch (action) {
+      case 'add-purchase':
+        this.onAddPurchaseOrder();
+        break;
+      case 'add-sales':
+        this.onAddSalesOrder();
+        break;
+    }
+  }
+
+  getCustomActionButtons() {
+    return [
+      { text: '+ Purchase Order', action: 'add-purchase' },
+      { text: '+ Sales Order', action: 'add-sales' }
+    ];
+  }
+
+  onClear() {
+    this.query.set('');
+  }
+
+  deleteSelected() {
+    const count = this.selectedCount();
+    if (count === 0) return;
+    
+    const message = `Delete ${count} selected order${count > 1 ? 's' : ''}?`;
+    if (!confirm(message)) return;
+    
+    this.all.update((list) => list.filter((o) => !o.selected));
+    this.bumpSelection();
+  }
+
+  openEditorFor(order: Order) {
+    this.editing.set({ ...order });
+    this.editorOpen.set(true);
+  }
+
+  // Editor event handlers
+  handleSave(updated: Order) {
+    if (updated.id && this.all().some((o) => o.id === updated.id)) {
+      // Update existing order
+      this.all.update((list) => 
+        list.map((o) => (o.id === updated.id ? { ...o, ...updated } : o))
+      );
+    } else {
+      // Add new order
+      const prefix = updated.type === 'purchase' ? 'PO' : 'SO';
+      const existingIds = this.all().filter(o => o.type === updated.type).length;
+      const id = updated.id?.trim() || `${prefix}-${String(existingIds + 1).padStart(3, '0')}`;
+      this.all.update((list) => [{ ...updated, id, selected: false }, ...list]);
+    }
+    this.closeEditor();
+  }
+
+  handleDelete(id: string) {
+    if (confirm('Are you sure you want to delete this order?')) {
+      this.all.update((list) => list.filter((o) => o.id !== id));
+      this.closeEditor();
+    }
+  }
+
+  closeEditor() {
+    this.editorOpen.set(false);
+    this.editing.set(null);
+  }
+
+  // Get display name for supplier/customer
+  getSupplierName(id: string | undefined): string {
+    if (!id) return '';
+    const supplier = this.suppliers().find(s => s.id === id);
+    return supplier ? supplier.name : id;
+  }
+
+  getCustomerName(id: string | undefined): string {
+    if (!id) return '';
+    const customer = this.customers().find(c => c.id === id);
+    return customer ? customer.name : id;
+  }
+
+  getProductName(id: string | undefined): string {
+    if (!id) return '';
+    const product = this.products().find(p => p.id === id);
+    return product ? product.name : id;
+  }
+}

--- a/services/frontend/src/app/shared/header/header.html
+++ b/services/frontend/src/app/shared/header/header.html
@@ -87,8 +87,118 @@
           Institutional
         </button>
       </div>
+      
+      <!-- Order Filters -->
+      <div class="filter-dropdown" *ngIf="filterOpen && isOrderPage">
+        <!-- Type Filter -->
+        <div class="filter-section">
+          <button
+            class="filter-option"
+            [class.active]="typeFilter === 'all'"
+            (click)="onOrderTypeFilterClick('all')">
+            All Orders
+          </button>
+          <button
+            class="filter-option"
+            [class.active]="typeFilter === 'purchase'"
+            (click)="onOrderTypeFilterClick('purchase')">
+            Purchase Orders
+          </button>
+          <button
+            class="filter-option"
+            [class.active]="typeFilter === 'sales'"
+            (click)="onOrderTypeFilterClick('sales')">
+            Sales Orders
+          </button>
+        </div>
+        
+        <!-- Status Filter (shows different options based on type) -->
+        <div class="filter-section" *ngIf="typeFilter !== 'all'">
+          <div class="filter-label">Status</div>
+          <button
+            class="filter-option"
+            [class.active]="orderStatusFilter === 'all'"
+            (click)="onOrderStatusFilterClick('all')">
+            All Statuses
+          </button>
+          
+          <!-- Purchase Order Statuses -->
+          <ng-container *ngIf="typeFilter === 'purchase'">
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'placed'"
+              (click)="onOrderStatusFilterClick('placed')">
+              Placed
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'in_transit'"
+              (click)="onOrderStatusFilterClick('in_transit')">
+              In Transit
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'received'"
+              (click)="onOrderStatusFilterClick('received')">
+              Received
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'canceled'"
+              (click)="onOrderStatusFilterClick('canceled')">
+              Canceled
+            </button>
+          </ng-container>
+          
+          <!-- Sales Order Statuses -->
+          <ng-container *ngIf="typeFilter === 'sales'">
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'pending'"
+              (click)="onOrderStatusFilterClick('pending')">
+              Pending
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'allocated'"
+              (click)="onOrderStatusFilterClick('allocated')">
+              Allocated
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'in_transit'"
+              (click)="onOrderStatusFilterClick('in_transit')">
+              In Transit
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'delivered'"
+              (click)="onOrderStatusFilterClick('delivered')">
+              Delivered
+            </button>
+            <button
+              class="filter-option"
+              [class.active]="orderStatusFilter === 'canceled'"
+              (click)="onOrderStatusFilterClick('canceled')">
+              Canceled
+            </button>
+          </ng-container>
+        </div>
+      </div>
     </div>
     
-    <button class="primary" type="button" (click)="onAddClick()">{{ addButtonText }}</button>
+    <!-- Default Add Button -->
+    <button class="primary" type="button" *ngIf="showAddButton" (click)="onAddClick()">
+      {{ addButtonText }}
+    </button>
+    
+    <!-- Custom Action Buttons -->
+    <button 
+      class="primary" 
+      type="button" 
+      *ngFor="let btn of customActionButtons"
+      (click)="onCustomActionClick(btn.action)">
+      {{ btn.text }}
+    </button>
   </div>
 </header>

--- a/services/frontend/src/app/shared/header/header.ts
+++ b/services/frontend/src/app/shared/header/header.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ProductStatus } from '../../models/product.model';
 import { CustomerSegment } from '../../models/customer.model';
+import { OrderType, PurchaseOrderStatus, SalesOrderStatus } from '../../models/order.model';
 
 @Component({
   selector: 'app-header',
@@ -22,8 +23,14 @@ export class Header {
   // Customer-specific inputs
   @Input() segmentFilter?: CustomerSegment | 'all';
   
-  @Input() addButtonText = '+ Add product'; // Allow customization of add button text
-  @Input() showFilters = true; // Allow hiding filters for supplier page
+  // Order-specific inputs
+  @Input() typeFilter?: OrderType | 'all';
+  @Input() orderStatusFilter?: PurchaseOrderStatus | SalesOrderStatus | 'all';
+  
+  @Input() addButtonText = '+ Add product';
+  @Input() showFilters = true;
+  @Input() showAddButton = true;
+  @Input() customActionButtons: { text: string; action: string; }[] = [];
   
   @Output() queryChange = new EventEmitter<string>();
   @Output() openFilters = new EventEmitter<void>();
@@ -36,10 +43,15 @@ export class Header {
   @Output() segmentFilterSelect = new EventEmitter<CustomerSegment | 'all'>();
   @Output() addCustomer = new EventEmitter<void>();
   
+  // Order-specific outputs
+  @Output() typeFilterSelect = new EventEmitter<OrderType | 'all'>();
+  @Output() statusFilterSelect = new EventEmitter<PurchaseOrderStatus | SalesOrderStatus | 'all'>();
+  @Output() customAction = new EventEmitter<string>();
+  
   @Output() clearSearch = new EventEmitter<void>();
   @Output() deleteSelected = new EventEmitter<void>();
 
-  // Determine if this is customer page or product page
+  // Determine page type
   get isCustomerPage(): boolean {
     return this.segmentFilter !== undefined;
   }
@@ -48,11 +60,17 @@ export class Header {
     return this.statusFilter !== undefined;
   }
 
+  get isOrderPage(): boolean {
+    return this.typeFilter !== undefined;
+  }
+
   get hasActiveFilter(): boolean {
     if (this.isProductPage) {
       return this.statusFilter !== 'all';
     } else if (this.isCustomerPage) {
       return this.segmentFilter !== 'all';
+    } else if (this.isOrderPage) {
+      return this.typeFilter !== 'all' || this.orderStatusFilter !== 'all';
     }
     return false;
   }
@@ -69,11 +87,23 @@ export class Header {
     }
   }
 
+  onOrderTypeFilterClick(type: OrderType | 'all') {
+    this.typeFilterSelect.emit(type);
+  }
+
+  onOrderStatusFilterClick(status: PurchaseOrderStatus | SalesOrderStatus | 'all') {
+    this.statusFilterSelect.emit(status);
+  }
+
   onAddClick() {
     if (this.isCustomerPage) {
       this.addCustomer.emit();
     } else {
       this.addProduct.emit();
     }
+  }
+
+  onCustomActionClick(action: string) {
+    this.customAction.emit(action);
   }
 }


### PR DESCRIPTION
This PR implements the order management workflows:

- Added Order model with type guards, status helpers, and color mapping
- OrderPage container with routing (/orders)
- OrderListing table with search, filters, selection, and bulk delete
- OrderEditor modal for creating and updating orders
- Single Order component for row/details rendering
- Extended MockDataService with order CRUD operations
- Updated Header to include actions in orders