### PR TITLE
feat(ml_models): add training model scripts for XGBoost, SARIMAX, and…

### DIFF
--- a/ml-models/training-scripts/LSTM.ipynb
+++ b/ml-models/training-scripts/LSTM.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90844c64-a5d5-4912-8d2b-ee0d280fd224",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import LSTM, Dense, Dropout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cc8f7d9-f444-43d5-bcbc-eb3a7da805ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#read the related data \n",
+    "df= pd.read_csv(\"xxxxx.csv\",parse_dates = [\"date\"])\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a00edea5-8404-44ec-b248-616f80c432a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Fill NA values with 0 \n",
+    "df = df.fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c92b9b5-9f54-423b-b4a1-4ffc891873c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set date column as datetime\n",
+    "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "868c3b28-63c7-41a7-887b-94ae78c74be2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#convert all possible dtypes into float or integer if any other exists\n",
+    "df[\"xxxxx\"] = df[\"xxxxx\"].astype(int)\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efa0a3e8-e501-4d94-9b31-28f0f2ff2b4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#drop unrelated columns or columns include dtype object\n",
+    "df.drop(columns=[\"xxxx\", \"xxxx\", \"xxxx\"], inplace = True, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0727f057-1f5e-4341-9241-bb6abaa219da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define one product df if there exists more than one product\n",
+    "product_id = 0\n",
+    "product_df = df[df[\"product_id\"] == product_id].set_index(\"date\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2806ce1a-22b0-41b1-b427-919a0b107740",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Define targets and features\n",
+    "target = \"demand\"\n",
+    "features = [\"xxxx\", \"xxxx\", \"xxxx\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57fd4084-aa42-4b48-a89e-4fcfffeb0dd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Scaling\n",
+    "scaler_X = MinMaxScaler()\n",
+    "scaler_y = MinMaxScaler()\n",
+    "\n",
+    "X_scaled = scaler_X.fit_transform(product_df[features])\n",
+    "y_scaled = scaler_y.fit_transform(product_df[[target]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eafdcad9-130a-4580-b1e4-77d7a6bb26b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#def create_sequences(X, y, seq_length=14, horizon=7):\n",
+    "    X_seq, y_seq = [], []\n",
+    "    for i in range(len(X) - seq_length - horizon + 1):\n",
+    "        X_seq.append(X[i:i+seq_length])\n",
+    "        y_seq.append(y[i+seq_length:i+seq_length+horizon])\n",
+    "    return np.array(X_seq), np.array(y_seq)\n",
+    "\n",
+    "SEQ_LENGTH = 14  # look-back 14 days\n",
+    "HORIZON = 7      # predict next 7 days\n",
+    "\n",
+    "X_seq, y_seq = create_sequences(X_scaled, y_scaled, SEQ_LENGTH, HORIZON)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ece064fb-eb84-4ad7-b039-86d6f259af47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TRAIN/TEST SPLIT\n",
+    "split = int(len(X_seq) * 0.8)\n",
+    "X_train, X_test = X_seq[:split], X_seq[split:]\n",
+    "y_train, y_test = y_seq[:split], y_seq[split:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1be390c6-9806-4f3a-b1d0-649cf1673763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#construct the LSTM model\n",
+    "model_lstm = Sequential()\n",
+    "model_lstm.add(LSTM(64, activation='relu', input_shape=(SEQ_LENGTH, X_train.shape[2])))\n",
+    "model_lstm.add(Dense(HORIZON))\n",
+    "model_lstm.compile(optimizer='adam', loss='mse')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f82204e-12a4-46f8-8443-409d7d37d807",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TRAIN MODEL\n",
+    "history = model_lstm.fit(X_train, y_train, epochs=50, batch_size=16,\n",
+    "                    validation_split=0.2, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14892b10-2917-415c-863a-67035f7405ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#prediction\n",
+    "y_pred_scaled = model.predict(X_test)\n",
+    "y_pred = scaler_y.inverse_transform(y_pred_scaled.reshape(-1, HORIZON))\n",
+    "\n",
+    "y_test_actual = scaler_y.inverse_transform(y_test.reshape(-1, HORIZON))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f0e07e3-24f7-44ca-8cc8-61526d380a27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute RMSE per horizon step\n",
+    "for i in range(HORIZON):\n",
+    "    rmse = np.sqrt(mean_squared_error(y_test_actual[:, i], y_pred[:, i]))\n",
+    "    df_compare = pd.DataFrame({\n",
+    "        \"Actual\": y_test_actual[:, i],\n",
+    "        \"Predicted\": y_pred[:, i]\n",
+    "    })\n",
+    "    print(f\"\\nHorizon t+{i+1} | RMSE: {rmse:.2f}\")\n",
+    "    print(df_compare.head(10))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8820dad-0410-4166-a601-753141ac7311",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#visualize the results\n",
+    "plt.figure(figsize=(14,6))\n",
+    "plt.plot(y_test_actual[:,0], label='Actual t+1')\n",
+    "plt.plot(y_pred[:,0], label='Predicted t+1')\n",
+    "plt.xlabel('Samples')\n",
+    "plt.ylabel('Demand')\n",
+    "plt.title('LSTM Forecast - Day 1 of 7-step horizon')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:DeepLearning1]",
+   "language": "python",
+   "name": "conda-env-DeepLearning1-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ml-models/training-scripts/SARIMAX.ipynb
+++ b/ml-models/training-scripts/SARIMAX.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4070c28-8a49-4bd5-a16b-295573862b17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from statsmodels.tsa.statespace.sarimax import SARIMAX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d888b40-81b8-48e9-88d2-4af060e7ac7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#read the related data \n",
+    "df= pd.read_csv(\"xxxxx.csv\",parse_dates = [\"date\"])\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9949a9f-a037-4257-8c75-56a38b692b4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Fill NA values with 0 \n",
+    "df = df.fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a31cfffe-6099-4fe4-8d1c-351efdde5720",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set date column as datetime\n",
+    "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cabac60b-1b20-432f-bf58-d496e99869c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#convert all possible dtypes into float or integer if any other exists\n",
+    "df[\"xxxxx\"] = df[\"xxxxx\"].astype(int)\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1667b2c1-afa0-45b4-97fc-aedb97c5adf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#drop unrelated columns or columns include dtype object\n",
+    "df.drop(columns=[\"xxxxx\",\"xxxxx\",\"xxxxx\"], inplace = True, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cfc28af-ce72-409b-aa64-80203d9f747b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define one product df if there exists more than one product\n",
+    "product = 'productname'\n",
+    "df_prod = df[df['product_name'] == product].sort_values('date')\n",
+    "\n",
+    "#make date the index\n",
+    "df_prod = df_prod.set_index('date')  # make date the index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7017f347-6aaf-4198-a2ff-c45ee56976e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define target and exogenous factors that affect the Y variable\n",
+    "#use this if your df consists of only one product\n",
+    "target = df[\"target\"]\n",
+    "exog_features = [\"xxxx\", \"xxxx\", \"xxxx\"]\n",
+    "exog = df[exog_features]\n",
+    "\n",
+    "#use this if you convert your df into one product df with code before\n",
+    "endog = df_prod['target']\n",
+    "exog_cols = [\"xxxx\", \"xxxx\", \"xxxx\"]\n",
+    "exog = df_prod[exog_cols]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "088dcf0d-85ec-4128-aa73-0fc08d942c57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Split train/test (last 30 days as test)\n",
+    "#Use only related code according to your df\n",
+    "\n",
+    "#for one product df \n",
+    "train_target = target[:-30]\n",
+    "test_target = target[-30:]\n",
+    "train_exog = exog[:-30]\n",
+    "test_exog = exog[-30:]\n",
+    "\n",
+    "#for converted one product df\n",
+    "endog = df_prod['target']\n",
+    "exog = df_prod[exog_cols]\n",
+    "\n",
+    "train_endog, test_endog = endog[:-30], endog[-30:]\n",
+    "train_exog, test_exog = exog[:-30], exog[-30:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fcb7cc3-9fbf-4ac6-9c57-d8f8a45fe592",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Construct SARIMAX model \n",
+    "#Use only related code according to your df\n",
+    "\n",
+    "#for one product df\n",
+    "model_sarimax = SARIMAX(\n",
+    "    train_target,\n",
+    "    exog=train_exog,\n",
+    "    order=(1,1,1),\n",
+    "    seasonal_order=(1,1,1,7),\n",
+    "    enforce_stationarity=False,\n",
+    "    enforce_invertibility=False\n",
+    ")\n",
+    "\n",
+    "model_fit = model_sarimax.fit(disp=False)\n",
+    "print(model_fit.summary())\n",
+    "\n",
+    "#for converted one product df\n",
+    "model_sarimax = SARIMAX(train_endog,\n",
+    "                exog=train_exog,\n",
+    "                order=(1,1,1),\n",
+    "                seasonal_order=(1,1,1,7),\n",
+    "                enforce_stationarity=False,\n",
+    "                enforce_invertibility=False)\n",
+    "\n",
+    "sarimax_res = model_sarimax.fit(disp=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc4e5d4f-2aaf-4511-9a80-6a6cdc45c34a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Forecast\n",
+    "#Use only related code according to your df\n",
+    "\n",
+    "#for one product df\n",
+    "forecast = model_fit.get_forecast(steps=30, exog=test_exog)\n",
+    "forecast_mean = forecast.predicted_mean\n",
+    "forecast_ci = forecast.conf_int()\n",
+    "\n",
+    "#for converted one product df\n",
+    "# Forecast 7 days recursively\n",
+    "horizon = 7\n",
+    "preds = []\n",
+    "history_endog = train_endog.copy()\n",
+    "history_exog = train_exog.copy()\n",
+    "\n",
+    "preds = sarimax_res.get_forecast(steps=len(test_endog), exog=test_exog)\n",
+    "y_pred = preds.predicted_mean  # now y_pred.shape == test_endog.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7735122-5a5f-4b56-88e1-8417283453f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Calculate RMSE value\n",
+    "#Use only related code according to your df\n",
+    "\n",
+    "#for one product df\n",
+    "for target in targets:\n",
+    "    rmse = np.sqrt(mean_squared_error(test_target, forecast_mean))\n",
+    "    print(f\"Test RMSE: {rmse:.2f}\")\n",
+    "\n",
+    "#for converted one product df\n",
+    "rmse = np.sqrt(mean_squared_error(test_endog, y_pred))\n",
+    "print(f\"SARIMAX RMSE: {rmse:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "293b5e2b-71f3-4442-aefe-bbdeed171520",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#compare actual and predicted values\n",
+    "\n",
+    "#for one product df\n",
+    "results = pd.DataFrame({\n",
+    "    \"actual\": test_target,\n",
+    "    \"forecast\": forecast_mean\n",
+    "})\n",
+    "print(results.head(15))\n",
+    "\n",
+    "#for converted one product df\n",
+    "for i in range(horizon):\n",
+    "    rmse = np.sqrt(mean_squared_error(y_test_actual[:, i], y_pred[:, i]))\n",
+    "    print(f\"RMSE t+{i+1}: {rmse:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56288f3e-f444-4f87-867c-a51e226493b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Visualize the final result\n",
+    "\n",
+    "#for one product df\n",
+    "plt.figure(figsize=(12,5))\n",
+    "plt.plot(test_target.index, test_target, label=\"Actual\")\n",
+    "plt.plot(test_target.index, forecast_mean, label=\"Forecast\")\n",
+    "plt.fill_between(test_target.index, forecast_ci.iloc[:,0], forecast_ci.iloc[:,1], color='pink', alpha=0.3)\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "#for converted one product df\n",
+    "# Plot\n",
+    "plt.figure(figsize=(12,5))\n",
+    "plt.plot(test_endog.index, test_endog.values, linestyle='--', label='Actual')\n",
+    "plt.plot(test_endog.index, y_pred.values, label='SARIMAX Predicted')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:DeepLearning1]",
+   "language": "python",
+   "name": "conda-env-DeepLearning1-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ml-models/training-scripts/XGBoost.ipynb
+++ b/ml-models/training-scripts/XGBoost.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cea4d112-6071-4daf-83a6-fca5a38d3e24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from xgboost import XGBRegressor\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d87c1cc4-c36a-4271-98a2-b10be0b817c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#read the related data \n",
+    "df= pd.read_csv(\"xxxxx.csv\",parse_dates = [\"date\"])\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92e3d41a-c4c2-4a08-9d5a-57ba9ff560d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Fill NA values with 0 \n",
+    "df = df.fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3da54f7-627c-418d-9d7e-203a3574893f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set date column as datetime\n",
+    "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "138fc8fa-2838-462a-a383-d9ae1655a1e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#convert all possible dtypes into float or integer if any other exists\n",
+    "df[\"xxxxx\"] = df[\"xxxxx\"].astype(int)\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef71bc58-ace3-4992-8a76-ce215da8f9ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#drop unrelated columns or columns include dtype object\n",
+    "df.drop(columns=[\"xxxxx\"], inplace = True, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8d0ad92-d354-4676-9cbd-e14e2b8a1efa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define lags to identify past observations to use for training the model\n",
+    "#target column indicates the Y variable for the model\n",
+    "df[\"lag_1\"] = df[\"target\"].shift(1)\n",
+    "df[\"lag_7\"] = df[\"target\"].shift(7)\n",
+    "df[\"rolling_mean_7\"] = df[\"target\"].shift(1).rolling(7).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "202eb243-d3de-4b0b-9e54-f11c892c90b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#drop NaN values occured from defining lag phase\n",
+    " df.dropna()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb9617f-a4cc-4c14-a4d9-47f6e10a4f79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Define forecast horizon and targets for the forecasting model\n",
+    "#do not forget that the target indicates Y variable\n",
+    "horizon = 7\n",
+    "targets = []\n",
+    "for i in range(1, horizon + 1):\n",
+    "    df[f\"target_t+{i}\"] = df[\"target\"].shift(-i)\n",
+    "    targets.append(f\"target_t+{i}\")\n",
+    "\n",
+    "df = df.dropna()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c169126e-8096-4b14-9d20-8df5d6868778",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define x and y variables\n",
+    "#while defining x, use related or unrelated columns\n",
+    "x = df.drop(columns=[\"xxxx\"] + targets)\n",
+    "y = df[targets]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18f5d17c-b5e6-4236-939c-49094d05fe92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set train/test split\n",
+    "train_mask = df[\"date\"] < (df[\"date\"].max() - pd.Timedelta(days=30))\n",
+    "x_train, x_test = x[train_mask], x[~train_mask]\n",
+    "y_train, y_test = y[train_mask], y[~train_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45c22307-639f-4421-ac97-02c17e7db4fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#construct the XGBoost model\n",
+    "model_xgb = XGBRegressor(\n",
+    "    n_estimators=500,\n",
+    "    learning_rate=0.03,\n",
+    "    max_depth=6,\n",
+    "    subsample=0.8,\n",
+    "    colsample_bytree=0.8,\n",
+    "    random_state=42\n",
+    ")\n",
+    "\n",
+    "models = {}\n",
+    "for i, target in enumerate(targets, start=1):\n",
+    "    m = model_xgb.fit(x_train, y_train[target])\n",
+    "    models[target] = m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e31cc4d-c109-4115-990f-cf68bcd56e03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#make predictions\n",
+    "preds = {}\n",
+    "for target, m in models.items():\n",
+    "    preds[target] = m.predict(x_test)\n",
+    "\n",
+    "preds = pd.DataFrame(preds, index=x_test.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "811481b8-4689-49f7-b197-5c42819b9b32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate RMSE per horizon step\n",
+    "for target in targets:\n",
+    "    rmse = np.sqrt(mean_squared_error(y_test[target], preds[target]))\n",
+    "    print(f\"RMSE for {target}: {rmse:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fa7649c-9c78-4c47-a03c-cae5c5ed2ad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#print results,examine actual and predicted values\n",
+    "results = pd.concat([df.loc[x_test.index, [\"date\", \"productId\"]], y_test, preds], axis=1)\n",
+    "print(results.head(14))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "180b07a2-3736-4776-a7ee-e10ab14934a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#visualize the predictions\n",
+    "#7 days forecast\n",
+    "horizon = preds.columns  # ['target_t+1', ..., 'target_t+7']\n",
+    "\n",
+    "for i, col in enumerate(horizon, start=1):\n",
+    "    plt.figure(figsize=(12, 6))\n",
+    "    plt.plot(y_test.index, y_test[col], label=f'Actual {col}', linestyle='--')\n",
+    "    plt.plot(preds.index, preds[col], label=f'Predicted {col}', alpha=0.7)\n",
+    "\n",
+    "    plt.xlabel('Date Index')\n",
+    "    plt.ylabel('Demand')\n",
+    "    plt.title(f'XGBoost Forecast ({col})')\n",
+    "    plt.legend()\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:DeepLearning1]",
+   "language": "python",
+   "name": "conda-env-DeepLearning1-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
… LSTM

This commit adds three Jupyter Notebook scripts under the ml_models module:
- XGBoost.ipynb: Gradient boosting model for inventory forecasting
- SARIMAX.ipynb: Time series model with seasonality and exogenous variables
- LSTM.ipynb: Deep learning recurrent model for sequential demand prediction

These models will serve as baseline training scripts for forecasting experiments in the inventory management system.