### PR TITLE
Feat/forecast training

### DIFF
--- a/services/forecast/README.md
+++ b/services/forecast/README.md
@@ -1,20 +1,27 @@
-# Forecast Service (PoC)
+# Forecast Service
 
-FastAPI service for daily demand forecasting. Trains models (async) and serves synchronous forecasts via REST. Reads Inventory reporting endpoints over HTTP only (no direct DB links).
+FastAPI service for daily demand forecasting. Trains models and serves synchronous forecasts via REST. Reads Inventory reporting endpoints over HTTP only (no direct DB links).
 
 ## Highlights
-- REST-only to Inventory: `/api/v1/reporting/product-day-sales`, `/api/v1/reporting/product-day-promo`
-- Daily features: calendar flags (in-service), promoPct, offerActiveShare, lags/MA (builder stub)
-- Models: starts with a simple baseline (MA7) for PoC; upgrade to GBM later
-- Storage: filesystem for model artifacts (Docker volume friendly)
-- Background training: FastAPI BackgroundTasks (simple, in-process)
+- REST-only to Inventory: `/api/v1/reporting/product-day-sales`, `/api/v1/reporting/product-day-promo`, `/api/v1/reporting/day-offer-stats`
+- Features: calendar flags (in-service), promoPct, offerActiveShare, day-offer stats, lags/MA
+- Models: baseline MA7 fallback + XGBoost three-head model (`xgb_three`: h1, y7-sum, y14-sum)
+- Storage: filesystem for model artifacts under `MODEL_DIR` + Postgres for registry and forecasts
+- Background training: in-process; auto-activates the newly trained model by default
+- Countable UoMs are rounded (adet, koli, paket, çuval, şişe) for daily and sums
+
+## Architecture & Data Flow
+- Inventory provides operational data and reporting views (sales by day/product, promos, day-level offer pressure).
+- Forecast pulls features from Inventory over HTTP, builds per-product training matrices, and trains global models.
+- Trained artifacts are saved on disk; model registry and forecast results are persisted in `forecast_db`.
+- Forecast endpoint loads the single active model and returns point forecasts, prediction intervals and confidence.
 
 ## Run (dev)
 
 1) Install deps:
    `pip install -r services/forecast/requirements.txt`
 
-2) Start API:
+2) Start API (include :app):
    `uvicorn services.forecast.app.main:app --reload --port 8100`
 
 3) Training runs as in-process background tasks (no extra worker). For stability while training, prefer a single API worker:
@@ -23,22 +30,69 @@ FastAPI service for daily demand forecasting. Trains models (async) and serves s
 ## Env Vars
 - `INVENTORY_BASE_URL` (e.g., http://localhost:8000)
 - `MODEL_DIR` (default: ./services/forecast/models)
-- `FORECAST_DB_DSN` (optional; PoC can skip DB writes)
+- `FORECAST_DB_DSN` (Postgres, e.g., `postgresql://user:pass@localhost:5432/forecast_db`)
+
+Tips
+- Keep DSN as a single line (no newlines). Test it with: `psql "$FORECAST_DB_DSN" -c '\dt'`.
+- Start Uvicorn with module:attribute import string, e.g. `services.forecast.app.main:app`.
 
 ## API
-- POST `/train` (async): queues training using BackgroundTasks; returns `{taskId}`
-- GET  `/train/status/{taskId}`
-- GET  `/train/models/active` — returns the active model metadata
-- POST `/train/activate/{modelVersionId}` — sets a model version active
+- POST `/train` (async): queue training; body `{algorithm:'xgb_three'|'baseline', trainWindowDays?:int, hyperparams?:{}, autoActivate?:bool}` → `{taskId}`
+  - xgb_three honors `hyperparams` (e.g., max_depth, eta/learning_rate, subsample, colsample_bytree, min_child_weight, reg_lambda, reg_alpha, n_estimators, early_stopping_rounds)
+  - On success the new model auto-activates (set `autoActivate:false` to skip)
+- POST `/train/tune` (sync): one-off random search; query/body params `trials`, `trainWindowDays`, `seed`, `asOfDate?`, `trainBest` (default true). Returns best hyperparams/metrics and optionally trains+activates the best.
+- GET  `/train/models/active` — current active model metadata
+- POST `/train/activate/{modelVersionId}` — activate a specific version (deactivates others)
 - GET  `/train/models` — list model versions (desc by trained_at)
 - GET  `/train/models/{modelVersionId}` — get model version details
-- POST `/forecast` (sync): `{productIds, horizonDays, asOfDate?}` → daily[] + sum
+- POST `/forecast` (sync): `{productIds, horizonDays(1|7|14), asOfDate?, returnDaily?}` → per-product {daily[], sum, predictionInterval, confidence}
+  - Uses active xgb_three if present; fallback MA7 otherwise
+  - For countable UoMs, daily and sum are rounded to integers; PI bounds are rounded >= 0
+  - Tip: if Inventory has no recent data, pass `asOfDate` near last actuals
+
+### Curl examples
+- Train (36 months, custom params):
+```
+curl -X POST 'http://127.0.0.1:8100/train' \
+  -H 'Content-Type: application/json' \
+  -d '{"algorithm":"xgb_three","trainWindowDays":1095,"hyperparams":{"max_depth":6,"learning_rate":0.05,"subsample":0.8,"colsample_bytree":0.8,"n_estimators":1000}}'
+```
+- Tune (20 trials, auto-train best):
+```
+curl -X POST 'http://127.0.0.1:8100/train/tune?trials=20&trainWindowDays=1095&seed=42&trainBest=true'
+```
+- Forecast (anchor asOf to last known actuals if needed):
+```
+curl -X POST 'http://127.0.0.1:8100/forecast' \
+  -H 'Content-Type: application/json' \
+  -d '{"productIds":[1001,1008],"horizonDays":7,"asOfDate":"2025-06-30","returnDaily":true}'
+```
 
 ## Notes
-- Calendar flags are computed locally (no CSV), based on the same logic as `calendar_events.py`.
-- For PoC, forecasts use a baseline MA7; swap-in real models incrementally.
-- Confidence and prediction intervals are returned per product using historical volatility and empirical residuals.
+- Calendar flags are computed locally (same logic as `calendar_events.py`).
+- Confidence: volatility-based score. PI: conformal residuals per horizon head.
+- Router aligns history window with model inference when xgb_three is active.
+- Root `/` redirects to `/docs`; `/favicon.ico` returns 204.
+
+### Features & Targets (xgb_three)
+- h1 daily model: uses lags/MA and exogenous for t+1.
+- y7/y14 sum models: use window aggregates of exogenous + calendar counts.
+- Training window is configurable; inference uses `max(365, training_window_days/3)` for history alignment.
+
+### Rounding (countable UoMs)
+- For UoMs in {adet, koli, paket, çuval, şişe}, daily yhat is rounded to nearest integer ≥ 0, sum recomputed from rounded dailies. PI bounds are also integer and ≥ 0 (sum-level only).
+
+### Confidence details
+- Volatility (IQR-trimmed coefficient of variation), Trend (Spearman + monotonicity, last 30d), Weekly seasonality proxy, Data completeness.
+- Blend weights: 30% volatility, 25% trend, 10% weekly, 35% completeness.
 
 ## Future Plan
-- Weekly retraining: add a simple cron/K8s Job or CLI that hits `/train` and activates the new version after validation.
-- Backtesting and accuracy tracking: `forecast_accuracy` table is created to log per-product errors when actuals arrive; add a small job to compute and write errors daily.
+- Weekly retraining via cron/K8s Job.
+- Backtesting and accuracy tracking: compute daily errors into `forecast_accuracy`.
+
+## Troubleshooting
+- 404 on `/`: visit `/docs` or use `/health`.
+- Import error: ensure `:app` is present in the Uvicorn command.
+- JSON 422 on `/train`: send valid JSON like `{ "algorithm":"xgb_three","trainWindowDays":1095 }`.
+- DB 500s: verify `FORECAST_DB_DSN` is exported in the same shell as Uvicorn and the migration ran.
+- Very small forecasts near “today”: if Inventory data ends earlier (e.g., 2025‑06‑30), pass `asOfDate` near the last actuals.

--- a/services/forecast/app/features/confidence.py
+++ b/services/forecast/app/features/confidence.py
@@ -86,7 +86,7 @@ def calculate_confidence(sales: pd.Series) -> Dict[str, Any]:
         + 0.4 * completeness
     )
     score = int(round(overall))
-    level = "high" if score >= 70 else ("medium" if score >= 50 else "low")
+    level = "high" if score >= 65 else ("medium" if score >= 45 else "low")
     recommendation = (
         "reliable_for_planning" if level == "high" else ("use_with_caution" if level == "medium" else "needs_review")
     )

--- a/services/forecast/app/features/confidence.py
+++ b/services/forecast/app/features/confidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Any
 
+import numpy as np
 import pandas as pd
 
 
@@ -43,13 +44,21 @@ def calculate_confidence(sales: pd.Series) -> Dict[str, Any]:
     cv_scaled = cv / (cv + 0.5)  # in [0,1)
     volatility_score = max(0.0, 100.0 * (1.0 - min(1.0, cv_scaled)))
 
-    # 3) Recent trend stability (last 30d)
+    # 3) Recent trend stability (last 30d), step-aware
     recent = s.tail(30)
     if len(recent) >= 14:
         x = pd.Series(range(len(recent)), dtype=float)
         y = recent.reset_index(drop=True).astype(float)
-        corr = float(x.corr(y)) if y.std(ddof=1) else 0.0
-        trend_stability = min(100.0, 50.0 + abs(corr) * 50.0)
+        # Spearman (rank) correlation is more robust to step changes
+        try:
+            corr_s = float(x.corr(y, method="spearman")) if y.nunique() > 1 else 0.0
+        except Exception:
+            corr_s = 0.0
+        # Monotonicity ratio on a lightly smoothed series
+        y_smooth = y.ewm(alpha=0.3, adjust=False).mean()
+        diffs = np.sign(np.diff(y_smooth.to_numpy(dtype=float)))
+        monot = float(abs(diffs.sum()) / len(diffs)) if len(diffs) > 0 else 0.0  # in [0,1]
+        trend_stability = min(100.0, 50.0 + 25.0 * abs(corr_s) + 25.0 * monot)
     else:
         trend_stability = 50.0
 
@@ -68,10 +77,16 @@ def calculate_confidence(sales: pd.Series) -> Dict[str, Any]:
     else:
         completeness = min(100.0, 100.0 * len(s) / 365.0)
 
-    # Weighted overall
-    overall = 0.3 * volatility_score + 0.2 * trend_stability + 0.2 * seasonality_score + 0.3 * completeness
+    # Weighted overall (weekly seasonality de-weighted, completeness slightly upweighted)
+    # Weights: volatility 30%, trend 20%, weekly-seasonality 10%, data completeness 40%
+    overall = (
+        0.30 * volatility_score
+        + 0.20 * trend_stability
+        + 0.10 * seasonality_score
+        + 0.4 * completeness
+    )
     score = int(round(overall))
-    level = "high" if score >= 75 else ("medium" if score >= 50 else "low")
+    level = "high" if score >= 70 else ("medium" if score >= 50 else "low")
     recommendation = (
         "reliable_for_planning" if level == "high" else ("use_with_caution" if level == "medium" else "needs_review")
     )
@@ -88,4 +103,3 @@ def calculate_confidence(sales: pd.Series) -> Dict[str, Any]:
         },
         "recommendation": recommendation,
     }
-

--- a/services/forecast/app/features/windows.py
+++ b/services/forecast/app/features/windows.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import pandas as pd
+
+
+def _safe_dt(d: object) -> date:
+    return pd.to_datetime(d).date()
+
+
+def build_date_indexed(df: pd.DataFrame, date_col: str = "date") -> pd.DataFrame:
+    out = df.copy()
+    if date_col in out.columns:
+        out[date_col] = pd.to_datetime(out[date_col]).dt.normalize()
+        out = out.set_index(date_col).sort_index()
+    return out
+
+
+def densify_spine(start: date, end: date) -> pd.DataFrame:
+    idx = pd.date_range(start, end, freq="D")
+    return pd.DataFrame(index=idx)
+
+
+def aggregate_window(
+    start_excl: date,
+    horizon_days: int,
+    promo_by_day: pd.DataFrame,
+    offer_by_day: pd.DataFrame,
+    calendar_by_day: pd.DataFrame,
+) -> Dict[str, float]:
+    """Aggregate exogenous signals over the future window (t+1..t+H).
+
+    Inputs are date-indexed frames with columns:
+      - promo_by_day: promoPct (0..100)
+      - offer_by_day: offerAvgPct (0..100), offerMaxPct (0..100), activeOffersCount (int)
+      - calendar_by_day: is_weekend (bool), is_official_holiday (bool), is_ramadan, is_eid_fitr, is_eid_adha,
+                         is_valentines, is_mothers_day, is_teachers_day, is_ataturk_memorial, is_black_friday, is_back_to_school
+    """
+    start = pd.Timestamp(start_excl) + pd.Timedelta(days=1)
+    end = start + pd.Timedelta(days=horizon_days - 1)
+
+    # Slice
+    p = promo_by_day.loc[start:end] if len(promo_by_day) else pd.DataFrame()
+    o = offer_by_day.loc[start:end] if len(offer_by_day) else pd.DataFrame()
+    c = calendar_by_day.loc[start:end] if len(calendar_by_day) else pd.DataFrame()
+
+    res: Dict[str, float] = {}
+
+    # Promo window
+    if not p.empty and "promoPct" in p.columns:
+        s = pd.to_numeric(p["promoPct"], errors="coerce").fillna(0.0)
+        res["promo_pct_avg"] = float(s.mean())
+        res["promo_pct_max"] = float(s.max())
+        res["promo_days_count"] = int((s > 0).sum())
+    else:
+        res.update({"promo_pct_avg": 0.0, "promo_pct_max": 0.0, "promo_days_count": 0})
+
+    # Offer window
+    if not o.empty:
+        for col in ("offerAvgPct", "offerMaxPct"):
+            if col in o.columns:
+                s = pd.to_numeric(o[col], errors="coerce").fillna(0.0)
+                res[f"{col}_avg"] = float(s.mean())
+                res[f"{col}_max"] = float(s.max())
+            else:
+                res[f"{col}_avg"] = 0.0
+                res[f"{col}_max"] = 0.0
+        if "activeOffersCount" in o.columns:
+            s = pd.to_numeric(o["activeOffersCount"], errors="coerce").fillna(0.0)
+            res["active_offers_count_avg"] = float(s.mean())
+            res["active_offers_count_max"] = float(s.max())
+        else:
+            res["active_offers_count_avg"] = 0.0
+            res["active_offers_count_max"] = 0.0
+    else:
+        res.update({
+            "offerAvgPct_avg": 0.0,
+            "offerAvgPct_max": 0.0,
+            "offerMaxPct_avg": 0.0,
+            "offerMaxPct_max": 0.0,
+            "active_offers_count_avg": 0.0,
+            "active_offers_count_max": 0.0,
+        })
+
+    # Calendar window counts
+    flags = [
+        "is_weekend",
+        "is_official_holiday",
+        "is_ramadan",
+        "is_eid_fitr",
+        "is_eid_adha",
+        "is_valentines",
+        "is_mothers_day",
+        "is_teachers_day",
+        "is_ataturk_memorial",
+        "is_black_friday",
+        "is_back_to_school",
+    ]
+    if not c.empty:
+        for f in flags:
+            if f in c.columns:
+                s = c[f].astype(bool)
+                res[f"{f}_count"] = int(s.sum())
+            else:
+                res[f"{f}_count"] = 0
+    else:
+        for f in flags:
+            res[f"{f}_count"] = 0
+
+    return res
+
+
+def daily_weights(
+    start_excl: date,
+    horizon_days: int,
+    promo_by_day: pd.DataFrame,
+    offer_by_day: pd.DataFrame,
+    calendar_by_day: pd.DataFrame,
+    alpha_promo: float = 0.3,
+    alpha_offer: float = 0.2,
+    alpha_weekend: float = 0.15,
+    alpha_holiday: float = 0.25,
+) -> List[float]:
+    """Compute simple positive weights for each future day t+1..t+H.
+    Weight ∝ 1 + αp*promoPct + αo*offerAvgPct + αw*is_weekend + αh*is_official_holiday.
+    promo/offer are scaled 0..1 (percent/100).
+    """
+    start = pd.Timestamp(start_excl) + pd.Timedelta(days=1)
+    end = start + pd.Timedelta(days=horizon_days - 1)
+
+    p = promo_by_day.loc[start:end] if len(promo_by_day) else pd.DataFrame()
+    o = offer_by_day.loc[start:end] if len(offer_by_day) else pd.DataFrame()
+    c = calendar_by_day.loc[start:end] if len(calendar_by_day) else pd.DataFrame()
+
+    out: List[float] = []
+    days = pd.date_range(start, end, freq="D")
+    for d in days:
+        promo = float(p.loc[d, "promoPct"]) if (not p.empty and d in p.index and "promoPct" in p.columns) else 0.0
+        offer = float(o.loc[d, "offerAvgPct"]) if (not o.empty and d in o.index and "offerAvgPct" in o.columns) else 0.0
+        is_wknd = bool(c.loc[d, "is_weekend"]) if (not c.empty and d in c.index and "is_weekend" in c.columns) else False
+        is_hol = bool(c.loc[d, "is_official_holiday"]) if (not c.empty and d in c.index and "is_official_holiday" in c.columns) else False
+        w = 1.0 + alpha_promo * (promo / 100.0) + alpha_offer * (offer / 100.0)
+        if is_wknd:
+            w += alpha_weekend
+        if is_hol:
+            w += alpha_holiday
+        out.append(max(0.0, float(w)))
+
+    s = sum(out) or 1.0
+    return [w / s for w in out]
+

--- a/services/forecast/app/main.py
+++ b/services/forecast/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse, Response
 
 from .routers.train import router as train_router
 from .routers.forecast import router as forecast_router
@@ -14,3 +15,14 @@ app.include_router(forecast_router, prefix="/forecast", tags=["Forecast"])
 def health():
     return {"status": "ok"}
 
+
+@app.get("/", include_in_schema=False)
+def root():
+    # Friendly landing: redirect to interactive API docs
+    return RedirectResponse(url="/docs")
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+def favicon():
+    # Avoid noisy 404s when browsers request a favicon
+    return Response(status_code=204)

--- a/services/forecast/app/models/xgb_three.py
+++ b/services/forecast/app/models/xgb_three.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:
+    import xgboost as xgb
+except Exception:  # pragma: no cover
+    xgb = None  # type: ignore
+
+from ..clients.inventory import InventoryClient
+from ..config import settings
+from ..features.calendar import build_calendar
+from ..features.assembler import add_lags_ma
+from ..features.windows import build_date_indexed, densify_spine, aggregate_window
+
+
+@dataclass
+class HeadArtifact:
+    model_path: str
+    feature_names: List[str]
+    q10: float
+    q90: float
+
+
+@dataclass
+class XGBThreeArtifact:
+    version_label: str
+    model_name: str
+    algorithm: str
+    training_window_days: int
+    h1: HeadArtifact
+    y7: HeadArtifact
+    y14: HeadArtifact
+
+
+def _df_from_rows(rows: List[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows or [])
+    if not df.empty and "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"]).dt.normalize()
+    return df
+
+
+def _prep_series_per_product(
+    product_id: int,
+    spine: pd.DataFrame,
+    sales_df: pd.DataFrame,
+    promo_df: pd.DataFrame,
+    offer_df: pd.DataFrame,
+    cal_df: pd.DataFrame,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    s = sales_df[sales_df["productId"] == product_id][["date", "salesUnits", "offerActiveShare"]].copy() if not sales_df.empty else pd.DataFrame(columns=["date","salesUnits","offerActiveShare"])
+    p = promo_df[promo_df["productId"] == product_id][["date", "promoPct"]].copy() if not promo_df.empty else pd.DataFrame(columns=["date","promoPct"])
+    s = s.set_index("date").sort_index()
+    p = p.set_index("date").sort_index()
+    o = offer_df.set_index("date").sort_index()
+    c = cal_df.set_index("date").sort_index()
+
+    sdf = spine.join(s, how="left").fillna({"salesUnits": 0.0, "offerActiveShare": 0.0})
+    pdf = spine.join(p, how="left").fillna({"promoPct": 0.0})
+    odf = spine.join(o, how="left").fillna({"offerAvgPct": 0.0, "offerMaxPct": 0.0, "activeOffersCount": 0})
+    cdf = spine.join(c, how="left").fillna(False)
+    return sdf, pdf, odf, cdf
+
+
+def _make_examples_for_product(
+    product_id: int,
+    sdf: pd.DataFrame,
+    pdf: pd.DataFrame,
+    odf: pd.DataFrame,
+    cdf: pd.DataFrame,
+    max_h: int = 14,
+) -> Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
+    # Add lags/MA
+    ddf = sdf.reset_index().rename(columns={"index": "date"})
+    ddf = add_lags_ma(ddf, ["salesUnits"]).sort_values("date")
+    ddf["date"] = pd.to_datetime(ddf["date"]).dt.normalize()
+    ddf = ddf.set_index("date").sort_index()
+
+    # Build examples for each t where full horizon fits
+    dates = ddf.index
+    # We'll compute y at t+1, sum7, sum14
+    X1_rows: List[Dict] = []
+    y1_vals: List[float] = []
+    X7_rows: List[Dict] = []
+    y7_vals: List[float] = []
+    X14_rows: List[Dict] = []
+    y14_vals: List[float] = []
+
+    # Helper to get window target sum safely
+    def sum_future(start_excl_ts: pd.Timestamp, horizon: int) -> float:
+        start = start_excl_ts + pd.Timedelta(days=1)
+        end = start + pd.Timedelta(days=horizon - 1)
+        s = ddf.loc[start:end, "salesUnits"] if (start in ddf.index or end in ddf.index) else pd.Series(dtype=float)
+        return float(pd.to_numeric(s, errors="coerce").fillna(0.0).sum()) if len(s) else 0.0
+
+    for t in dates:
+        # ensure we have full horizon within index
+        if (t + pd.Timedelta(days=1)) not in ddf.index:
+            continue
+        if (t + pd.Timedelta(days=7)) not in ddf.index:
+            continue
+        if (t + pd.Timedelta(days=max_h)) not in ddf.index:
+            continue
+
+        row_base: Dict[str, float] = {
+            "productId": int(product_id),
+        }
+        # Historical lags/MAs at t
+        for col in ["salesUnits_lag7", "salesUnits_lag14", "salesUnits_lag28", "salesUnits_ma7", "salesUnits_ma14", "salesUnits_ma28"]:
+            val = float(ddf.loc[t, col]) if col in ddf.columns and pd.notna(ddf.loc[t, col]) else 0.0
+            row_base[col] = val
+        for col in ["offerActiveShare"]:
+            # past realized at t
+            val = float(ddf.loc[t, col]) if col in ddf.columns and pd.notna(ddf.loc[t, col]) else 0.0
+            row_base[f"{col}_t"] = val
+
+        # Exogenous for t+1 (point) for h1
+        tp1 = t + pd.Timedelta(days=1)
+        promo_d1 = float(pdf.loc[tp1, "promoPct"]) if tp1 in pdf.index else 0.0
+        offer_avg_d1 = float(odf.loc[tp1, "offerAvgPct"]) if tp1 in odf.index else 0.0
+        offer_max_d1 = float(odf.loc[tp1, "offerMaxPct"]) if tp1 in odf.index else 0.0
+        active_cnt_d1 = float(odf.loc[tp1, "activeOffersCount"]) if tp1 in odf.index else 0.0
+
+        X1 = dict(row_base)
+        X1.update({
+            "promoPct_d1": promo_d1,
+            "offerAvgPct_d1": offer_avg_d1,
+            "offerMaxPct_d1": offer_max_d1,
+            "activeOffersCount_d1": active_cnt_d1,
+        })
+        y1 = float(ddf.loc[tp1, "salesUnits"]) if tp1 in ddf.index else 0.0
+
+        # Window aggregates for y7/y14
+        w7 = aggregate_window(t.date(), 7, pdf, odf, cdf)
+        w14 = aggregate_window(t.date(), 14, pdf, odf, cdf)
+
+        X7 = dict(row_base)
+        X7.update(w7)
+        y7 = sum_future(t, 7)
+
+        X14 = dict(row_base)
+        X14.update(w14)
+        y14 = sum_future(t, 14)
+
+        X1_rows.append(X1)
+        y1_vals.append(y1)
+        X7_rows.append(X7)
+        y7_vals.append(y7)
+        X14_rows.append(X14)
+        y14_vals.append(y14)
+
+    X1_df = pd.DataFrame(X1_rows)
+    y1_s = pd.Series(y1_vals, name="y1")
+    X7_df = pd.DataFrame(X7_rows)
+    y7_s = pd.Series(y7_vals, name="y7")
+    X14_df = pd.DataFrame(X14_rows)
+    y14_s = pd.Series(y14_vals, name="y14")
+    return X1_df, y1_s, X7_df, y7_s, X14_df, y14_s
+
+
+def _time_split(df: pd.DataFrame, y: pd.Series, time_col: Optional[str] = None, val_frac: float = 0.15, test_frac: float = 0.15):
+    n = len(df)
+    if n == 0:
+        return (df, y, df, y, df, y)
+    i1 = max(1, int(round(n * (1.0 - (val_frac + test_frac)))))
+    i2 = max(i1 + 1, int(round(n * (1.0 - test_frac))))
+    X_tr, y_tr = df.iloc[:i1], y.iloc[:i1]
+    X_val, y_val = df.iloc[i1:i2], y.iloc[i1:i2]
+    X_te, y_te = df.iloc[i2:], y.iloc[i2:]
+    return X_tr, y_tr, X_val, y_val, X_te, y_te
+
+
+def _normalize_overrides(overrides: Optional[Dict]) -> Dict:
+    """Normalize user-provided hyperparams to xgboost param names and supported keys.
+
+    Supported aliases:
+      - learning_rate -> eta
+      - n_estimators / num_boost_round (returned separately)
+    """
+    o = dict(overrides or {})
+    if "learning_rate" in o and "eta" not in o:
+        o["eta"] = o.pop("learning_rate")
+    return o
+
+
+def _build_xgb_params(seed: int, overrides: Optional[Dict]) -> Tuple[Dict, int, int, Dict]:
+    """Return (params, num_boost_round, early_stopping_rounds, used_hparams)"""
+    o = _normalize_overrides(overrides)
+    # Defaults
+    params = {
+        "objective": "reg:squarederror",
+        "eval_metric": "rmse",
+        "max_depth": 7,
+        "eta": 0.08,
+        "subsample": 0.8,
+        "colsample_bytree": 0.8,
+        "min_child_weight": 3,
+        "seed": seed,
+    }
+    # Optional regularization
+    if "reg_lambda" in o:
+        params["reg_lambda"] = o["reg_lambda"]
+    if "reg_alpha" in o:
+        params["reg_alpha"] = o["reg_alpha"]
+    # Merge known overrides
+    for k in ("max_depth", "eta", "subsample", "colsample_bytree", "min_child_weight"):
+        if k in o:
+            params[k] = o[k]
+    # Booster rounds & ES
+    num_boost_round = int(o.get("n_estimators", o.get("num_boost_round", 1200)))
+    early_stopping_rounds = int(o.get("early_stopping_rounds", 50))
+
+    used = {
+        "max_depth": params["max_depth"],
+        "eta": params["eta"],
+        "subsample": params["subsample"],
+        "colsample_bytree": params["colsample_bytree"],
+        "min_child_weight": params["min_child_weight"],
+        "reg_lambda": params.get("reg_lambda", None),
+        "reg_alpha": params.get("reg_alpha", None),
+        "n_estimators": num_boost_round,
+        "early_stopping_rounds": early_stopping_rounds,
+    }
+    return params, num_boost_round, early_stopping_rounds, used
+
+
+def _train_head(
+    X: pd.DataFrame,
+    y: pd.Series,
+    seed: int = 42,
+    overrides: Optional[Dict] = None,
+) -> Tuple[Optional[object], Dict[str, float], Tuple[float, float], Dict]:
+    if xgb is None:
+        return None, {}, (0.0, 0.0), {}
+    # Fill NaNs
+    X = X.fillna(0.0)
+    # Split timewise
+    X_tr, y_tr, X_val, y_val, X_te, y_te = _time_split(X, y)
+    dtrain = xgb.DMatrix(X_tr, label=y_tr)
+    dval = xgb.DMatrix(X_val, label=y_val)
+    dtest = xgb.DMatrix(X_te, label=y_te)
+
+    params, num_boost_round, early_stopping_rounds, used = _build_xgb_params(seed, overrides)
+    evallist = [(dtrain, "train"), (dval, "eval")]
+    bst = xgb.train(params, dtrain, num_boost_round=num_boost_round, evals=evallist, early_stopping_rounds=early_stopping_rounds, verbose_eval=False)
+
+    # Metrics
+    yhat_te = bst.predict(dtest)
+    y_true = y_te.to_numpy(dtype=float)
+    rmse = float(np.sqrt(np.mean((yhat_te - y_true) ** 2))) if len(y_true) else 0.0
+    mae = float(np.mean(np.abs(yhat_te - y_true))) if len(y_true) else 0.0
+    mape = float(np.mean(np.abs((yhat_te - y_true) / np.maximum(1e-6, y_true)))) * 100.0 if len(y_true) else 0.0
+
+    # Conformal quantiles from validation residuals
+    yhat_val = bst.predict(dval)
+    yv = y_val.to_numpy(dtype=float)
+    res = (yv - yhat_val) if len(yv) else np.array([0.0])
+    q10 = float(np.quantile(res, 0.10))
+    q90 = float(np.quantile(res, 0.90))
+
+    return bst, {"rmse": rmse, "mae": mae, "mape": mape}, (q10, q90), used
+
+
+def train_xgb_three(task_id: str, params: Dict) -> Tuple[XGBThreeArtifact, Dict[str, Dict[str, float]], Dict]:
+    """Train three heads: h1 daily, y7 sum, y14 sum. Returns artifact spec and metrics per head."""
+    rng_seed = int(params.get("seed", 42))
+    window_days = int(params.get("trainWindowDays", 1095))  # ~36 months
+    as_of = params.get("asOfDate")
+    if as_of:
+        as_of = pd.to_datetime(as_of).date()
+    else:
+        as_of = date.today()
+
+    start = as_of - timedelta(days=window_days + 60)  # headroom for lags and horizons
+    end = as_of
+
+    # Fetch data
+    inv = InventoryClient()
+    sales_rows = inv.get_product_day_sales(start, end, None)
+    promo_rows = inv.get_product_day_promo(start, end, None)
+    offer_rows = inv.get_day_offer_stats(start, end)
+
+    sales_df = _df_from_rows(sales_rows)
+    promo_df = _df_from_rows(promo_rows)
+    offer_df = _df_from_rows(offer_rows)
+
+    # Determine product ids present
+    product_ids = sorted(set([int(x) for x in (sales_df["productId"].unique().tolist() if "productId" in sales_df.columns else [])]))
+    # If none via sales, fallback to promo set
+    if not product_ids and "productId" in promo_df.columns and not promo_df.empty:
+        product_ids = sorted(set(int(x) for x in promo_df["productId"].unique().tolist()))
+
+    # Calendar
+    cal = build_calendar(start, end)
+    cal["date"] = pd.to_datetime(cal["date"]).dt.normalize()
+    cal_df = cal
+
+    # Dense spine
+    spine = densify_spine(start, end)
+
+    # Collect examples
+    X1_list: List[pd.DataFrame] = []
+    y1_list: List[pd.Series] = []
+    X7_list: List[pd.DataFrame] = []
+    y7_list: List[pd.Series] = []
+    X14_list: List[pd.DataFrame] = []
+    y14_list: List[pd.Series] = []
+
+    for pid in product_ids:
+        sdf, pdf, odf, cdf = _prep_series_per_product(pid, spine, sales_df, promo_df, offer_df, cal_df)
+        X1_df, y1_s, X7_df, y7_s, X14_df, y14_s = _make_examples_for_product(pid, sdf, pdf, odf, cdf)
+        if not X1_df.empty:
+            X1_list.append(X1_df)
+            y1_list.append(y1_s)
+        if not X7_df.empty:
+            X7_list.append(X7_df)
+            y7_list.append(y7_s)
+        if not X14_df.empty:
+            X14_list.append(X14_df)
+            y14_list.append(y14_s)
+
+    if not X1_list:
+        raise RuntimeError("No training data assembled for h1")
+
+    X1 = pd.concat(X1_list, ignore_index=True)
+    y1 = pd.concat(y1_list, ignore_index=True)
+    X7 = pd.concat(X7_list, ignore_index=True) if X7_list else pd.DataFrame()
+    y7 = pd.concat(y7_list, ignore_index=True) if y7_list else pd.Series(dtype=float)
+    X14 = pd.concat(X14_list, ignore_index=True) if X14_list else pd.DataFrame()
+    y14 = pd.concat(y14_list, ignore_index=True) if y14_list else pd.Series(dtype=float)
+
+    overrides = params.get("hyperparams", {})
+    # Train heads (apply same overrides to each head)
+    bst1, m1, (q10_1, q90_1), used_hp = _train_head(
+        X1.drop(columns=["productId"], errors="ignore"), y1, seed=rng_seed, overrides=overrides
+    )
+    if not X7.empty:
+        bst7, m7, (q10_7, q90_7), _ = _train_head(
+            X7.drop(columns=["productId"], errors="ignore"), y7, seed=rng_seed, overrides=overrides
+        )
+    else:
+        bst7, m7, (q10_7, q90_7) = (None, {}, (0.0, 0.0))
+    if not X14.empty:
+        bst14, m14, (q10_14, q90_14), _ = _train_head(
+            X14.drop(columns=["productId"], errors="ignore"), y14, seed=rng_seed, overrides=overrides
+        )
+    else:
+        bst14, m14, (q10_14, q90_14) = (None, {}, (0.0, 0.0))
+
+    # Persist artifacts
+    version_label = f"xgb_three-{pd.Timestamp.utcnow().strftime('%Y%m%d%H%M%S')}"
+    root = Path(settings.MODEL_DIR) / "xgb_three" / version_label
+    (root / "h1").mkdir(parents=True, exist_ok=True)
+    (root / "y7").mkdir(parents=True, exist_ok=True)
+    (root / "y14").mkdir(parents=True, exist_ok=True)
+
+    f1 = list(X1.drop(columns=["productId"], errors="ignore").columns)
+    f7 = list(X7.drop(columns=["productId"], errors="ignore").columns) if not X7.empty else []
+    f14 = list(X14.drop(columns=["productId"], errors="ignore").columns) if not X14.empty else []
+
+    art1_path = str(root / "h1" / "model.json")
+    art7_path = str(root / "y7" / "model.json")
+    art14_path = str(root / "y14" / "model.json")
+
+    if bst1 is not None:
+        bst1.save_model(art1_path)
+    if bst7 is not None:
+        bst7.save_model(art7_path)
+    if bst14 is not None:
+        bst14.save_model(art14_path)
+
+    # Save metadata
+    meta = {
+        "version_label": version_label,
+        "model_name": "xgb_three",
+        "algorithm": "xgb_three",
+        "training_window_days": window_days,
+        "heads": {
+            "h1": {"features": f1, "q10": q10_1, "q90": q90_1},
+            "y7": {"features": f7, "q10": q10_7, "q90": q90_7},
+            "y14": {"features": f14, "q10": q10_14, "q90": q90_14},
+        },
+    }
+    (root / "meta.json").write_text(json.dumps(meta, indent=2))
+
+    artifact = XGBThreeArtifact(
+        version_label=version_label,
+        model_name="xgb_three",
+        algorithm="xgb_three",
+        training_window_days=window_days,
+        h1=HeadArtifact(model_path=art1_path, feature_names=f1, q10=q10_1, q90=q90_1),
+        y7=HeadArtifact(model_path=art7_path, feature_names=f7, q10=q10_7, q90=q90_7),
+        y14=HeadArtifact(model_path=art14_path, feature_names=f14, q10=q10_14, q90=q90_14),
+    )
+
+    metrics = {"h1": m1, "y7": m7, "y14": m14}
+    return artifact, metrics, used_hp
+
+
+def tune_xgb_three(params: Dict) -> Dict:
+    """One-off tuning: random search over hyperparams without saving artifacts.
+
+    Returns dict with bestHyperparams, bestMetrics, and trials summary.
+    """
+    rng_seed = int(params.get("seed", 42))
+    window_days = int(params.get("trainWindowDays", 1095))
+    trials = int(params.get("tuneTrials", 20))
+    as_of = params.get("asOfDate")
+    if as_of:
+        as_of = pd.to_datetime(as_of).date()
+    else:
+        as_of = date.today()
+
+    start = as_of - timedelta(days=window_days + 60)
+    end = as_of
+
+    inv = InventoryClient()
+    sales_rows = inv.get_product_day_sales(start, end, None)
+    promo_rows = inv.get_product_day_promo(start, end, None)
+    offer_rows = inv.get_day_offer_stats(start, end)
+
+    sales_df = _df_from_rows(sales_rows)
+    promo_df = _df_from_rows(promo_rows)
+    offer_df = _df_from_rows(offer_rows)
+    product_ids = sorted(set([int(x) for x in (sales_df["productId"].unique().tolist() if "productId" in sales_df.columns else [])]))
+    if not product_ids and "productId" in promo_df.columns and not promo_df.empty:
+        product_ids = sorted(set(int(x) for x in promo_df["productId"].unique().tolist()))
+
+    cal = build_calendar(start, end)
+    cal["date"] = pd.to_datetime(cal["date"]).dt.normalize()
+    spine = densify_spine(start, end)
+
+    X1_list: List[pd.DataFrame] = []
+    y1_list: List[pd.Series] = []
+    X7_list: List[pd.DataFrame] = []
+    y7_list: List[pd.Series] = []
+    X14_list: List[pd.DataFrame] = []
+    y14_list: List[pd.Series] = []
+    for pid in product_ids:
+        sdf, pdf, odf, cdf = _prep_series_per_product(pid, spine, sales_df, promo_df, offer_df, cal)
+        X1_df, y1_s, X7_df, y7_s, X14_df, y14_s = _make_examples_for_product(pid, sdf, pdf, odf, cdf)
+        if not X1_df.empty:
+            X1_list.append(X1_df)
+            y1_list.append(y1_s)
+        if not X7_df.empty:
+            X7_list.append(X7_df)
+            y7_list.append(y7_s)
+        if not X14_df.empty:
+            X14_list.append(X14_df)
+            y14_list.append(y14_s)
+
+    if not X1_list:
+        raise RuntimeError("No training data assembled for tuning")
+
+    X1 = pd.concat(X1_list, ignore_index=True)
+    y1 = pd.concat(y1_list, ignore_index=True)
+    X7 = pd.concat(X7_list, ignore_index=True) if X7_list else pd.DataFrame()
+    y7 = pd.concat(y7_list, ignore_index=True) if y7_list else pd.Series(dtype=float)
+    X14 = pd.concat(X14_list, ignore_index=True) if X14_list else pd.DataFrame()
+    y14 = pd.concat(y14_list, ignore_index=True) if y14_list else pd.Series(dtype=float)
+
+    rng = np.random.default_rng(rng_seed)
+
+    def sample_space() -> Dict:
+        return {
+            "max_depth": int(rng.choice([4, 6, 8, 10])),
+            "eta": float(rng.choice([0.03, 0.05, 0.08, 0.1])),
+            "subsample": float(rng.choice([0.7, 0.8, 1.0])),
+            "colsample_bytree": float(rng.choice([0.7, 0.8, 1.0])),
+            "min_child_weight": int(rng.choice([1, 3, 5])),
+            "reg_lambda": float(rng.choice([0.0, 1.0, 5.0])),
+            "reg_alpha": float(rng.choice([0.0, 0.1, 1.0])),
+            "n_estimators": int(rng.choice([600, 800, 1000, 1200])),
+            "early_stopping_rounds": 50,
+        }
+
+    best = None
+    trials_out: List[Dict] = []
+    for i in range(max(1, trials)):
+        hp = sample_space()
+        # Train heads quickly (no saving)
+        bst1, m1, _, used1 = _train_head(X1.drop(columns=["productId"], errors="ignore"), y1, seed=rng_seed + i, overrides=hp)
+        if not X7.empty:
+            _, m7, _, _ = _train_head(X7.drop(columns=["productId"], errors="ignore"), y7, seed=rng_seed + i, overrides=hp)
+        else:
+            m7 = {"rmse": float("inf")}
+        if not X14.empty:
+            _, m14, _, _ = _train_head(X14.drop(columns=["productId"], errors="ignore"), y14, seed=rng_seed + i, overrides=hp)
+        else:
+            m14 = {"rmse": float("inf")}
+
+        score = 0.6 * float(m7.get("rmse", 1e9)) + 0.3 * float(m14.get("rmse", 1e9)) + 0.1 * float(m1.get("rmse", 1e9))
+        rec = {"trial": i + 1, "hyperparams": hp, "metrics": {"h1": m1, "y7": m7, "y14": m14}, "score": score}
+        trials_out.append(rec)
+        if best is None or score < best[0]:
+            best = (score, hp, {"h1": m1, "y7": m7, "y14": m14})
+
+    result = {
+        "bestHyperparams": best[1] if best else {},
+        "bestMetrics": best[2] if best else {},
+        "trials": trials_out,
+        "asOfDate": as_of.isoformat(),
+        "trainWindowDays": window_days,
+    }
+    return result
+
+
+def load_artifact(artifact_path: str) -> Optional[XGBThreeArtifact]:
+    try:
+        meta_p = Path(artifact_path) / "meta.json"
+        meta = json.loads(meta_p.read_text())
+        heads = meta.get("heads", {})
+        root = Path(artifact_path)
+        return XGBThreeArtifact(
+            version_label=meta.get("version_label", "unknown"),
+            model_name=meta.get("model_name", "xgb_three"),
+            algorithm=meta.get("algorithm", "xgb_three"),
+            training_window_days=int(meta.get("training_window_days", 365)),
+            h1=HeadArtifact(str(root / "h1" / "model.json"), heads.get("h1", {}).get("features", []), float(heads.get("h1", {}).get("q10", 0.0)), float(heads.get("h1", {}).get("q90", 0.0))),
+            y7=HeadArtifact(str(root / "y7" / "model.json"), heads.get("y7", {}).get("features", []), float(heads.get("y7", {}).get("q10", 0.0)), float(heads.get("y7", {}).get("q90", 0.0))),
+            y14=HeadArtifact(str(root / "y14" / "model.json"), heads.get("y14", {}).get("features", []), float(heads.get("y14", {}).get("q10", 0.0)), float(heads.get("y14", {}).get("q90", 0.0))),
+        )
+    except Exception:
+        return None
+
+
+def _predict_head(model_path: str, feature_names: List[str], X: pd.DataFrame) -> np.ndarray:
+    if xgb is None:
+        return np.zeros(len(X))
+    bst = xgb.Booster()
+    bst.load_model(model_path)
+    d = xgb.DMatrix(X.fillna(0.0)[feature_names])
+    return bst.predict(d)
+
+
+def infer_xgb_three(
+    artifact: XGBThreeArtifact,
+    product_ids: List[int],
+    as_of: date,
+    horizon_days: int,
+) -> Dict[int, Dict[str, object]]:
+    """Predict for given products and horizon using saved artifacts.
+
+    Returns dict per productId with keys:
+      - daily (List[float])
+      - sum (float)
+      - lower (float)
+      - upper (float)
+    """
+    inv = InventoryClient()
+    # History window for lags/MA
+    start_hist = as_of - timedelta(days=max(365, artifact.training_window_days // 3))
+    end_hist = as_of
+    # Fetch history and future exogenous
+    sales_rows = inv.get_product_day_sales(start_hist, end_hist, product_ids)
+    promo_rows_hist = inv.get_product_day_promo(start_hist, end_hist, product_ids)
+    promo_rows_future = inv.get_product_day_promo(as_of + timedelta(days=1), as_of + timedelta(days=horizon_days), product_ids)
+    offer_rows_hist = inv.get_day_offer_stats(start_hist, end_hist)
+    offer_rows_future = inv.get_day_offer_stats(as_of + timedelta(days=1), as_of + timedelta(days=horizon_days))
+
+    sales_df = _df_from_rows(sales_rows)
+    promo_hist_df = _df_from_rows(promo_rows_hist)
+    promo_future_df = _df_from_rows(promo_rows_future)
+    offer_hist_df = _df_from_rows(offer_rows_hist)
+    offer_future_df = _df_from_rows(offer_rows_future)
+
+    # Calendar across history+horizon
+    cal = build_calendar(start_hist, as_of + timedelta(days=horizon_days))
+    cal["date"] = pd.to_datetime(cal["date"]).dt.normalize()
+
+    # Prepare outputs
+    results: Dict[int, Dict[str, object]] = {}
+
+    # Build per-product feature row at t=as_of
+    for pid in product_ids:
+        # Build series
+        # History spine up to as_of for lags
+        hist_spine = densify_spine(start_hist, as_of)
+        sdf, pdf_hist, odf_hist, cdf_hist = _prep_series_per_product(pid, hist_spine, sales_df, promo_hist_df, offer_hist_df, cal)
+        # Future frames for window aggregates and weights
+        fut_spine = densify_spine(as_of + timedelta(days=1), as_of + timedelta(days=horizon_days))
+        # Promo future per product
+        pf = promo_future_df[promo_future_df["productId"] == pid][["date", "promoPct"]].copy() if not promo_future_df.empty else pd.DataFrame(columns=["date","promoPct"])
+        pf = pf.set_index(pd.to_datetime(pf["date"]).dt.normalize() if not pf.empty else pd.Index([])).sort_index()
+        pf.index.name = None
+        pf = fut_spine.join(pf.drop(columns=["date"], errors="ignore"), how="left").fillna({"promoPct": 0.0})
+        of = _df_from_rows(offer_rows_future).set_index("date") if not offer_future_df.empty else pd.DataFrame()
+        if not of.empty:
+            of = fut_spine.join(of, how="left").fillna({"offerAvgPct": 0.0, "offerMaxPct": 0.0, "activeOffersCount": 0})
+        else:
+            of = fut_spine.copy()
+            of["offerAvgPct"] = 0.0
+            of["offerMaxPct"] = 0.0
+            of["activeOffersCount"] = 0
+        cf = cal.copy()
+        cf["date"] = pd.to_datetime(cf["date"]).dt.normalize()
+        cf = cf.set_index("date").sort_index()
+        cf = fut_spine.join(cf, how="left").fillna(False)
+
+        # Lags/MAs up to as_of
+        hist_df = sdf.reset_index().rename(columns={"index": "date"})
+        hist_df = add_lags_ma(hist_df, ["salesUnits"]).sort_values("date")
+        hist_df["date"] = pd.to_datetime(hist_df["date"]).dt.normalize()
+        hist_df = hist_df.set_index("date").sort_index()
+        t = pd.Timestamp(as_of)
+        row_base: Dict[str, float] = {
+            "productId": int(pid),
+        }
+        for col in ["salesUnits_lag7", "salesUnits_lag14", "salesUnits_lag28", "salesUnits_ma7", "salesUnits_ma14", "salesUnits_ma28"]:
+            val = float(hist_df.loc[t, col]) if col in hist_df.columns and t in hist_df.index and pd.notna(hist_df.loc[t, col]) else 0.0
+            row_base[col] = val
+        val = float(hist_df.loc[t, "offerActiveShare"]) if "offerActiveShare" in hist_df.columns and t in hist_df.index and pd.notna(hist_df.loc[t, "offerActiveShare"]) else 0.0
+        row_base["offerActiveShare_t"] = val
+
+        # Predict
+        if horizon_days == 1:
+            # Point exogenous for d1
+            d1 = pd.Timestamp(as_of + timedelta(days=1))
+            X = dict(row_base)
+            X.update({
+                "promoPct_d1": float(pf.loc[d1, "promoPct"]) if d1 in pf.index else 0.0,
+                "offerAvgPct_d1": float(of.loc[d1, "offerAvgPct"]) if d1 in of.index else 0.0,
+                "offerMaxPct_d1": float(of.loc[d1, "offerMaxPct"]) if d1 in of.index else 0.0,
+                "activeOffersCount_d1": float(of.loc[d1, "activeOffersCount"]) if d1 in of.index else 0.0,
+            })
+            Xdf = pd.DataFrame([X])
+            yhat = _predict_head(artifact.h1.model_path, artifact.h1.feature_names, Xdf)
+            y = float(max(0.0, yhat[0]))
+            lower = max(0.0, y + artifact.h1.q10)
+            upper = max(lower, y + artifact.h1.q90)
+            results[pid] = {"daily": [y], "sum": y, "lower": lower, "upper": upper}
+        else:
+            # Window aggregates for y7/y14
+            w = aggregate_window(as_of, horizon_days, pf, of, cf)
+            X = dict(row_base)
+            X.update(w)
+            Xdf = pd.DataFrame([X])
+            if horizon_days == 7:
+                yhat = _predict_head(artifact.y7.model_path, artifact.y7.feature_names, Xdf)
+                ysum = float(max(0.0, yhat[0]))
+                lower = max(0.0, ysum + artifact.y7.q10)
+                upper = max(lower, ysum + artifact.y7.q90)
+            else:
+                yhat = _predict_head(artifact.y14.model_path, artifact.y14.feature_names, Xdf)
+                ysum = float(max(0.0, yhat[0]))
+                lower = max(0.0, ysum + artifact.y14.q10)
+                upper = max(lower, ysum + artifact.y14.q90)
+
+            # Allocate daily weights
+            # Reuse promo/offer/calendar frames built above
+            from ..features.windows import daily_weights
+            weights = daily_weights(as_of, horizon_days, pf, of, cf)
+            daily_vals = [max(0.0, float(ysum * w)) for w in weights]
+            # Adjust rounding drift
+            drift = ysum - float(sum(daily_vals))
+            if abs(drift) > 1e-6 and len(daily_vals) > 0:
+                daily_vals[-1] += float(drift)
+                if daily_vals[-1] < 0:
+                    daily_vals[-1] = 0.0
+            results[pid] = {"daily": daily_vals, "sum": ysum, "lower": lower, "upper": upper}
+
+    return results

--- a/services/forecast/app/routers/train.py
+++ b/services/forecast/app/routers/train.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import uuid
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 
 from ..schemas import TrainRequest, TrainResponse
 from ..workers.background import run_training_job
+from ..models.xgb_three import tune_xgb_three, train_xgb_three
+from ..db import dal
 from ..db import dal
 
 
@@ -52,3 +54,61 @@ def get_model(model_version_id: int):
     """Get a single model version by id."""
     mv = dal.get_model_version(model_version_id)
     return mv or {}
+
+
+@router.post("/tune")
+def tune(
+    trials: int = 20,
+    trainWindowDays: int = 1095,
+    seed: int = 42,
+    asOfDate: str | None = None,
+    trainBest: bool = True,
+):
+    """Run a one-off random search to suggest better hyperparams.
+
+    - Returns the best hyperparams/metrics and (optionally) trains + activates the best model.
+    - This endpoint runs synchronously; prefer moderate trial counts (e.g., 10–30).
+    """
+    params = {
+        "tuneTrials": int(trials),
+        "trainWindowDays": int(trainWindowDays),
+        "seed": int(seed),
+    }
+    if asOfDate:
+        params["asOfDate"] = asOfDate
+    result = tune_xgb_three(params)
+
+    model_info = {}
+    if trainBest:
+        # Train with best hyperparams and auto-activate
+        hp = result.get("bestHyperparams", {})
+        tparams = {
+            "algorithm": "xgb_three",
+            "trainWindowDays": int(trainWindowDays),
+            "hyperparams": hp,
+            "autoActivate": True,
+        }
+        # Use a direct call to training (synchronous) to avoid background queue for this one-off
+        try:
+            artifact, metrics, used = train_xgb_three("tune_inline", tparams)
+            mv_metrics = {"h1": metrics.get("h1", {}), "y7": metrics.get("y7", {}), "y14": metrics.get("y14", {})}
+            mv_id = dal.insert_model_version(
+                model_name="xgb_three",
+                version_label=artifact.version_label,
+                algorithm="xgb_three",
+                artifact_path=str(artifact.h1.model_path).replace("/h1/model.json", ""),
+                training_window_days=int(trainWindowDays),
+                hyperparams=used,
+                metrics=mv_metrics,
+                is_active=False,
+            )
+            if mv_id:
+                dal.set_active_model_version(int(mv_id))
+                model_info = {"model_version_id": int(mv_id), "version_label": artifact.version_label}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to persist best model: {e}")
+
+    out = {"best": result}
+    if model_info:
+        out["trainedAndActivated"] = model_info
+    return out

--- a/services/forecast/app/schemas.py
+++ b/services/forecast/app/schemas.py
@@ -1,56 +1,56 @@
-from datetime import date, datetime
+from datetime import date as Date, datetime
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
 
 
 class TrainRequest(BaseModel):
-    scope: str = Field(default="global", description="'global' or 'product'")
-    productId: Optional[int] = None
-    trainWindowDays: int = 365
-    algorithm: str = "baseline"
-    hyperparams: dict = Field(default_factory=dict)
+    scope: str = Field(default="global", description="Training scope: 'global' for all products or 'product' for specific product", example="global")
+    productId: Optional[int] = Field(default=None, description="Required when scope='product'. Product ID to train model for", example=1001)
+    trainWindowDays: int = Field(default=1095, description="Number of days of historical data to use for training (36 months default)", example=1095)
+    algorithm: str = Field(default="xgb_three", description="ML algorithm to use", example="xgb_three")
+    hyperparams: dict = Field(default_factory=dict, description="XGBoost hyperparameters", example={"learning_rate": 0.1, "max_depth": 6, "n_estimators": 800})
 
 
 class TrainResponse(BaseModel):
-    taskId: str
-    status: str = "queued"
-    statusUrl: str
+    taskId: str = Field(description="Unique task identifier for tracking training progress", example="123e4567-e89b-12d3-a456-426614174000")
+    status: str = Field(default="queued", description="Current training status", example="queued")
+    statusUrl: str = Field(description="URL to check training status", example="/train/status/123e4567-e89b-12d3-a456-426614174000")
 
 
 class ForecastRequest(BaseModel):
-    productIds: List[int]
-    horizonDays: int = Field(default=7, description="1 | 7 | 14")
-    asOfDate: Optional[date] = None
-    returnDaily: bool = True
+    productIds: List[int] = Field(description="List of product IDs to forecast", example=[1001, 1002, 1003])
+    horizonDays: int = Field(default=7, description="Forecast horizon in days. Must be 1, 7, or 14", example=7)
+    asOfDate: Optional[Date] = Field(default=None, description="Date to forecast from (defaults to today)", example="2025-06-30")
+    returnDaily: bool = Field(default=True, description="Whether to return daily breakdown or just totals", example=True)
 
 
 class DailyForecast(BaseModel):
-    date: date
-    yhat: float
+    date: Date = Field(description="Forecast date", example="2025-07-01")
+    yhat: float = Field(description="Predicted sales units for this date", example=45.2)
 
 
 class PredictionInterval(BaseModel):
-    lowerBound: float
-    upperBound: float
+    lowerBound: float = Field(description="Lower bound of 80% confidence interval", example=85.3)
+    upperBound: float = Field(description="Upper bound of 80% confidence interval", example=156.7)
 
 
 class Confidence(BaseModel):
-    score: int
-    level: str
-    factors: Dict[str, Any]
-    recommendation: str
+    score: int = Field(description="Confidence score (0-100)", example=75)
+    level: str = Field(description="Confidence level description", example="medium")
+    factors: Dict[str, Any] = Field(description="Factors affecting confidence", example={"historical_pattern": "stable", "seasonal_effects": "moderate"})
+    recommendation: str = Field(description="Recommendation based on confidence", example="Reliable forecast with moderate seasonal variation")
 
 
 class ForecastPerProduct(BaseModel):
-    productId: int
-    daily: List[DailyForecast]
-    sum: float
-    predictionInterval: Optional[PredictionInterval] = None
-    confidence: Optional[Confidence] = None
+    productId: int = Field(description="Product ID", example=1001)
+    daily: List[DailyForecast] = Field(description="Daily forecast breakdown (empty if returnDaily=false)")
+    sum: float = Field(description="Total predicted sales over the horizon", example=289.4)
+    predictionInterval: Optional[PredictionInterval] = Field(default=None, description="80% confidence interval bounds")
+    confidence: Optional[Confidence] = Field(default=None, description="Confidence assessment for this forecast")
 
 
 class ForecastResponse(BaseModel):
-    forecasts: List[ForecastPerProduct]
-    modelVersion: str = "baseline-0.1"
-    modelType: Optional[str] = "baseline_ma7"
-    generatedAt: datetime = Field(default_factory=lambda: datetime.utcnow())
+    forecasts: List[ForecastPerProduct] = Field(description="Forecast results per product")
+    modelVersion: str = Field(default="xgb_three-latest", description="Model version used", example="xgb_three-20250913125620")
+    modelType: Optional[str] = Field(default="xgb_three", description="Model algorithm type", example="xgb_three")
+    generatedAt: datetime = Field(default_factory=lambda: datetime.utcnow(), description="Timestamp when forecast was generated")

--- a/services/forecast/app/workers/background.py
+++ b/services/forecast/app/workers/background.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 
 from ..config import settings
 from ..db import dal
+from ..models.xgb_three import train_xgb_three
 
 
 def run_training_job(task_id: str, params: Dict[str, Any]) -> None:
@@ -25,38 +26,69 @@ def run_training_job(task_id: str, params: Dict[str, Any]) -> None:
         if rid:
             dal.update_training_run(rid, "running")
 
-        # Simulate work (replace with real training pipeline later)
-        time.sleep(0.5)
-
-        model_name = "baseline"
-        version_label = "baseline-0.1"
-        algorithm = params.get("algorithm", "baseline_ma7")
-        train_window = int(params.get("trainWindowDays", 365))
-        artifact_dir = Path(settings.MODEL_DIR) / model_name / version_label
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-        artifact_path = artifact_dir / "model.json"
-        artifact = {
-            "taskId": task_id,
-            "algorithm": algorithm,
-            "hyperparams": params.get("hyperparams", {}),
-        }
-        artifact_path.write_text(json.dumps(artifact, indent=2))
-
-        backtest = {"backtest_metrics": {"1_day_mape": 0.20, "7_day_mape": 0.25, "14_day_mape": 0.30}}
-        mv_id = dal.insert_model_version(
-            model_name=model_name,
-            version_label=version_label,
-            algorithm=algorithm,
-            artifact_path=str(artifact_path),
-            training_window_days=train_window,
-            hyperparams=params.get("hyperparams", {}),
-            metrics=backtest,
-            is_active=False,
-        ) or None
+        algorithm = str(params.get("algorithm", "baseline_ma7"))
+        if algorithm == "xgb_three":
+            # Train three XGB heads and persist artifacts/metrics
+            artifact, metrics, used_hparams = train_xgb_three(task_id, params)
+            mv_metrics = {
+                "h1": metrics.get("h1", {}),
+                "y7": metrics.get("y7", {}),
+                "y14": metrics.get("y14", {}),
+            }
+            mv_id = dal.insert_model_version(
+                model_name="xgb_three",
+                version_label=artifact.version_label,
+                algorithm="xgb_three",
+                artifact_path=str((Path(settings.MODEL_DIR) / "xgb_three" / artifact.version_label).resolve()),
+                training_window_days=int(params.get("trainWindowDays", artifact.training_window_days)),
+                hyperparams=used_hparams or params.get("hyperparams", {}),
+                metrics=mv_metrics,
+                is_active=False,
+            ) or None
+            # Auto-activate the newly trained model
+            auto_activate = bool(params.get("autoActivate", True))
+            if mv_id and auto_activate:
+                try:
+                    dal.set_active_model_version(mv_id)
+                except Exception:
+                    pass
+        else:
+            # Baseline stub (existing behavior)
+            time.sleep(0.5)
+            model_name = "baseline"
+            version_label = "baseline-0.1"
+            train_window = int(params.get("trainWindowDays", 365))
+            artifact_dir = Path(settings.MODEL_DIR) / model_name / version_label
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            artifact_path = artifact_dir / "model.json"
+            artifact = {
+                "taskId": task_id,
+                "algorithm": algorithm,
+                "hyperparams": params.get("hyperparams", {}),
+            }
+            artifact_path.write_text(json.dumps(artifact, indent=2))
+            backtest = {"backtest_metrics": {"1_day_mape": 0.20, "7_day_mape": 0.25, "14_day_mape": 0.30}}
+            mv_id = dal.insert_model_version(
+                model_name=model_name,
+                version_label=version_label,
+                algorithm=algorithm,
+                artifact_path=str(artifact_path),
+                training_window_days=train_window,
+                hyperparams=params.get("hyperparams", {}),
+                metrics=backtest,
+                is_active=False,
+            ) or None
+            auto_activate = bool(params.get("autoActivate", True))
+            if mv_id and auto_activate:
+                try:
+                    dal.set_active_model_version(mv_id)
+                except Exception:
+                    pass
 
         if rid:
-            dal.update_training_run(rid, "succeeded", metrics=backtest, model_version_id=mv_id)
+            # For xgb_three, mv_metrics; for baseline, backtest
+            metrics_payload = mv_metrics if algorithm == "xgb_three" else backtest
+            dal.update_training_run(rid, "succeeded", metrics=metrics_payload, model_version_id=mv_id)
     except Exception as e:  # pragma: no cover - background failure path
         if rid:
             dal.update_training_run(rid, "failed", error_message=str(e))
-

--- a/services/forecast/requirements.txt
+++ b/services/forecast/requirements.txt
@@ -7,6 +7,7 @@ numpy>=1.26
 python-dateutil>=2.9
 holidays>=0.50
 scikit-learn>=1.5
+xgboost>=2.0
 psycopg[binary]>=3.2
 # celery==5.3.0  # Future: when we need distributed training
 # redis==5.0.0   # Future: with celery

--- a/services/forecast/setup.md
+++ b/services/forecast/setup.md
@@ -1,0 +1,173 @@
+# Forecast Service — Setup and Operations
+
+This guide explains the big picture, one‑time setup, how to run the service, how the data flows, the database tables, and the available APIs.
+
+## Big Picture
+
+- Services
+  - Inventory Service (Spring Boot + Postgres): owns operational data. Exposes reporting endpoints that serve the training/forecast features: daily sales, promos, and day‑level offer stats.
+  - Forecast Service (FastAPI + Python): pulls features from Inventory over HTTP, trains models, serves forecasts, and optionally persists results in its own DB.
+- Data stores
+  - `inventory_db`: operational schema + forecasting views (`inv_forecast` schema) that back the reporting APIs.
+  - `forecast_db`: model registry (`model_versions`, `training_runs`) and forecast outputs (`forecasts`, `forecast_items`, `forecast_accuracy`).
+  - Model artifacts: stored on the filesystem under `MODEL_DIR` (default: `services/forecast/models`).
+- Models
+  - Baseline MA7 (simple moving average) for quick fallback.
+  - XGBoost three‑head model (`xgb_three`): separate heads for next‑day (h=1), 7‑day sum, and 14‑day sum. Uses known‑future exogenous features (promos, offer pressure, calendar) and historical lags/MAs. Honors `hyperparams` from the /train request with early stopping.
+- Feature sources (via Inventory API)
+  - Daily sales: `date, productId, salesUnits, offerActiveShare(0..1)`
+  - Daily promo: `date, productId, promoPct(0..100)`
+  - Day offer stats: `date, activeOffersCount, offerAvgPct(0..100), offerMaxPct(0..100)`
+
+## One‑Time Setup
+
+1) Ensure Inventory is up and its reporting endpoints return data (migrations V1–V8 applied, service running):
+   - Sales: `GET /api/v1/reporting/product-day-sales?from=2024-01-01&to=2024-02-01&productId=1008`
+   - Promo: `GET /api/v1/reporting/product-day-promo?from=2024-01-01&to=2024-02-01&productId=1008`
+   - Offers: `GET /api/v1/reporting/day-offer-stats?from=2024-01-01&to=2024-02-01`
+
+2) Create and migrate `forecast_db` (one‑time)
+   - If using psql to a Dockerized Postgres, force TCP with `-h`:
+     - `psql -h localhost -U <user> -d forecast_db -f services/forecast/db/migrations/V1__init.sql`
+   - Or in pgAdmin: open a query window on `forecast_db` and execute the SQL file above.
+   - Verify tables:
+     - `psql -h localhost -U <user> -d forecast_db -c '\dt'`
+     - You should see: `model_versions`, `training_runs`, `forecasts`, `forecast_items`, `forecast_accuracy`.
+
+3) Configure environment variables for Forecast
+   - `FORECAST_DB_DSN=postgresql://<user>:<pass>@localhost:5432/forecast_db`
+   - `INVENTORY_BASE_URL=http://localhost:8000` (adjust host/port as needed)
+   - `MODEL_DIR=./services/forecast/models` (optional; default is already this path)
+   - zsh (temporary):
+     - `export FORECAST_DB_DSN='postgresql://admin:admin@localhost:5432/forecast_db'`
+     - `export INVENTORY_BASE_URL='http://localhost:8000'`
+   - zsh (persistent): add to `~/.zshrc` then `source ~/.zshrc`
+   - Ensure DSN is one line: `echo "$FORECAST_DB_DSN"` and test: `psql "$FORECAST_DB_DSN" -c '\dt'`
+
+## Run the Forecast Service
+
+1) Install dependencies
+   - `pip install -r services/forecast/requirements.txt`
+
+2) Start API (prefer single worker while training)
+   - `uvicorn services.forecast.app.main:app --port 8100 --workers 1`
+   - Root `/` redirects to `/docs`; health at `/health`.
+
+3) Health check
+   - `GET http://localhost:8100/health` → `{ "status": "ok" }`
+
+## Typical Flow (Train → Activate → Forecast)
+
+1) Train `xgb_three` (36 months lookback example)
+   - `POST /train`
+     - Body: `{ "algorithm": "xgb_three", "trainWindowDays": 1095, "hyperparams": { /* optional xgb params */ }, "autoActivate": true }`
+   - What happens:
+     - Forecast pulls features from Inventory for the window, builds datasets for h1/y7/y14, trains three models with early stopping, computes conformal prediction intervals, saves artifacts under `MODEL_DIR/xgb_three/<version>/`, and inserts a `model_versions` row with metrics.
+     - The new model auto‑activates by default (set `autoActivate:false` to skip).
+
+1b) One‑off tuning (optional)
+   - `POST /train/tune?trials=20&trainWindowDays=1095&seed=42&trainBest=true`
+   - Runs a random search over xgb params and returns bestHyperparams/metrics. If `trainBest=true`, trains and auto‑activates the best model.
+   - For large trials, prefer running outside peak hours; this endpoint is synchronous.
+
+2) Inspect and activate the trained model
+   - `GET /train/models` → list versions with metrics
+   - `POST /train/activate/{modelVersionId}` → sets this version active (others inactive)
+
+3) Request forecasts (saved to DB if `FORECAST_DB_DSN` is set)
+   - `POST /forecast`
+     - Examples:
+       - Next day: `{ "productIds": [1008,1009], "horizonDays": 1, "returnDaily": true }`
+       - 7 days: `{ "productIds": [1008,1009], "horizonDays": 7, "returnDaily": true }`
+       - 14 days: `{ "productIds": [1008,1009], "horizonDays": 14, "returnDaily": true }`
+   - Response includes per‑product `sum`, optional `daily[]`, `predictionInterval` (sum), and a volatility‑based `confidence` object. Results are written into `forecasts` + `forecast_items` when a DB is configured.
+
+4) Verify persistence (pgAdmin / psql)
+   - `SELECT * FROM model_versions ORDER BY trained_at DESC LIMIT 5;`
+   - `SELECT * FROM forecasts ORDER BY forecast_id DESC LIMIT 5;`
+   - `SELECT * FROM forecast_items WHERE forecast_id=<ID> ORDER BY forecast_date;`
+
+## Repository Map (Forecast)
+
+- `services/forecast/app/main.py` — FastAPI app factory
+- `services/forecast/app/routers/train.py` — Train endpoints (queue background job, registry ops)
+  - Includes `/train/tune` for one‑off random search and optional immediate training
+- `services/forecast/app/routers/forecast.py` — Forecast endpoint (uses active model or MA7 fallback)
+- `services/forecast/app/clients/inventory.py` — HTTP client for Inventory reporting APIs
+- `services/forecast/app/features/` — Feature builders
+  - `calendar.py` — TR holidays + Ramadan/Eids + special days
+  - `assembler.py` — Join sales, promos, calendar; add lags/MAs
+  - `windows.py` — Horizon window aggregates + daily weighting allocator
+- `services/forecast/app/models/` — Models
+  - `baseline.py` — MA7 baseline
+  - `xgb_three.py` — Three‑head XGBoost trainer/inference + artifact I/O + tuning helper
+- `services/forecast/app/db/` — DAL
+  - `dal.py` — Optional Postgres access (training_runs, model_versions, forecasts, forecast_items, forecast_accuracy)
+- `services/forecast/db/migrations/V1__init.sql` — Forecast DB schema
+
+## Forecast DB Schema
+
+- `model_versions`
+  - Registry of trained models. Columns: `model_version_id (PK)`, `model_name`, `version_label`, `algorithm`, `trained_at`, `artifact_path`, `training_window_days`, `hyperparams (JSONB)`, `metrics (JSONB)`, `is_active`.
+  - One row per version. Exactly one can be active at a time.
+  - New versions auto‑activate on successful training unless disabled.
+
+- `training_runs`
+  - Tracks training job executions. Columns: `training_run_id (PK)`, `model_version_id (FK nullable)`, `scope ('global'|'product')`, `product_id`, `started_at`, `finished_at`, `status ('queued'|'running'|'succeeded'|'failed')`, `params (JSONB)`, `metrics (JSONB)`, `error_message`.
+  - `model_version_id` filled after a successful run.
+  - Timestamp semantics: `started_at` is set when transitioning to RUNNING; `finished_at` when SUCCEEDED/FAILED.
+
+- `forecasts`
+  - Header for a forecast request. Columns: `forecast_id (PK)`, `requested_at`, `as_of_date`, `horizon_days`, `model_version_id (FK)`, `request_hash (unique)`, `created_by`, `note`.
+  - One row per forecast call.
+
+- `forecast_items`
+  - Per‑product, per‑day results. Columns: `forecast_item_id (PK)`, `forecast_id (FK -> forecasts ON DELETE CASCADE)`, `product_id`, `forecast_date`, `yhat`, `confidence (JSONB NOT NULL)`, `lower_bound`, `upper_bound`.
+  - Index on `(product_id, forecast_date)`.
+  - For countable UoMs, `yhat` is an integer (rounded in service before insert).
+
+- `forecast_accuracy`
+  - Backtesting and realized accuracy logging. Columns: `accuracy_id (PK)`, `product_id`, `forecast_date`, `horizon_days`, `predicted_value`, `actual_value`, `error_pct`, `model_version_id (FK)`, `calculated_at`.
+
+Relationships:
+- `training_runs.model_version_id` → `model_versions.model_version_id` (nullable until a run succeeds)
+- `forecasts.model_version_id` → `model_versions.model_version_id`
+- `forecast_items.forecast_id` → `forecasts.forecast_id` (cascade delete)
+- `forecast_accuracy.model_version_id` → `model_versions.model_version_id`
+
+## APIs
+
+Forecast Service (FastAPI):
+
+- Health
+  - `GET /health` → `{ "status": "ok" }`
+
+- Training
+  - `POST /train` — Queues background training. Body: `{ "algorithm": "xgb_three" | "baseline", "trainWindowDays": 365|1095, ... }` → `{ taskId, status, statusUrl }`
+    - xgb_three honors `hyperparams` and `autoActivate` (default true).
+  - `POST /train/tune` — One‑off random search; returns best hyperparams/metrics and can train+activate the best in the same call.
+  - `GET /train/status/{taskId}` — PoC stub: returns `{ status: 'queued' }` unless wired to a task store
+  - `GET /train/models/active` — Returns the currently active model version (if any)
+  - `POST /train/activate/{modelVersionId}` — Marks a model version active; deactivates others
+  - `GET /train/models` — Lists model versions (desc by `trained_at`)
+  - `GET /train/models/{modelVersionId}` — Returns a single model version
+
+- Forecast
+  - `POST /forecast` — Computes forecasts for given products and horizon.
+    - Request: `{ "productIds": [..], "horizonDays": 1|7|14, "asOfDate"?: YYYY‑MM‑DD, "returnDaily"?: true }`
+    - Response: `{ forecasts: [ { productId, daily[], sum, predictionInterval, confidence } ], modelVersion, modelType, generatedAt }`
+    - Behavior: uses active `xgb_three` if present; otherwise falls back to MA7 baseline.
+    - Rounding: for countable UoMs (adet, koli, paket, çuval, şişe) daily and sum are rounded to integers; PI bounds rounded ≥ 0.
+    - Tip: if Inventory has no recent data (e.g., simulator ended), set `asOfDate` near the last actual date so lags/MA are informative.
+
+External (Inventory Service) — consumed by Forecast:
+- `GET /api/v1/reporting/product-day-sales?from&to&productId` — daily sales by product
+- `GET /api/v1/reporting/product-day-promo?from&to&productId` — daily promo percent by product
+- `GET /api/v1/reporting/day-offer-stats?from&to` — day‑level offer pressure (no product filter)
+
+## Tips & Troubleshooting
+
+- Prefer single API worker (`--workers 1`) while training to avoid duplicate background tasks.
+- If psql tries a Unix socket, use `-h localhost` to force TCP to your container.
+- If training fetches no data: shorten `trainWindowDays` to match your dataset and ensure Inventory views have data up to today.
+- Forecast client uses `productId` in query params to match Inventory; keep this aligned with the Inventory controller.


### PR DESCRIPTION
### What does this PR do?
* Adds a global XGBoost “three-head” model (`h=1` daily, 7-day sum, 14-day sum) with artifact saving and conformal prediction intervals.
* Integrates the active model into the Forecast endpoint, including integer rounding for countable UoMs (`adet`, `koli`, `paket`, `çuval`, `şişe`).
* Honors hyperparams in `/train`, and adds a one-off tuning endpoint (`/train/tune`) to find better params and auto-train/activate the best.
* Improves confidence scoring: de-weights weekly seasonality, upweights completeness, and makes trend stability robust to step changes (Spearman + monotonicity).
* Fixes DB JSON handling and `training_runs` timestamps.
* Adds a root redirect to `/docs` and updates setup and `README` with end-to-end instructions.

### Why is this change needed?
* We need stronger forecasts than `MA7` for the demo and beyond, direct weekly/biweekly predictions (to avoid recursive error compounding), and the ability to quickly find good XGBoost settings.
* Business wants integer outputs for countable units and clearer confidence that better reflects predictable seasonal step changes (e.g., Ramadan).
* Developer UX improvements: simple startup, docs, and consistent API behavior.

### How can a reviewer test this?

## Environment
Set env vars in the same shell you’ll run the API:
`export FORECAST_DB_DSN='postgresql://admin@localhost/forecast_db'`
`export INVENTORY_BASE_URL='http://localhost:8000'`

Ensure Inventory reporting endpoints return data for your date ranges.

## Start the API
`uvicorn services.forecast.app.main --port 8100 --workers 1`

Verify: `GET /health` → 200; `GET /` → redirects to `/docs`

## Train a model (36 months)
`POST /train` with `{"algorithm":"xgb_three","trainWindowDays":1095}`

Expect `202 Accepted`; after completion, `GET /train/models` shows new row; `GET /train/models/active` shows it active.

Alternatively: `POST /train/tune?trials=10&trainWindowDays=1095&trainBest=true` to search, then auto-train/activate best.

## Forecast
If your Inventory data ends around 2025-06-30, set `asOfDate`:
`POST /forecast` with `{"productIds":[1001,1008], "horizonDays":14, "asOfDate":"2025-06-30", "returnDaily":true}`

Check:
* Countable UoM daily and sum are integers.
* `predictionInterval` covers the sum, not per-day.
* Confidence returns `score`/`level`/`factors`.

## Persistence
Verify rows in `forecast_db`:
* `model_versions` (new version with hyperparams/metrics)
* `forecasts` and `forecast_items` after `/forecast`
* `training_runs` with `started_at` and `finished_at` set correctly

## Nice-to-check (optional)
* `/train` with custom hyperparams (e.g., `max_depth`, `eta`) takes effect (`model_versions.hyperparams` shows used values).
* `/train/activate/{id}` switches the active model.

## Scope
Files touched include: models (`xgb_three`), routers (`train`, `forecast`), clients (`inventory`), features (`windows`, `confidence`), DAL (JSON/timestamps), `main` (redirect), docs (`README`, `setup`), `requirements`.

## Risks
* `/train/tune` runs synchronously; keep trials modest in dev.
* Confidence weights changed; expect slight shifts vs prior runs.
* Rounding persists integer `yhat` for countable UoMs (intended by business).

## Roll-back plan
Activate a previous model with `POST /train/activate/{oldId}`, or run without an active model to fall back to `MA7`.
Revert docs/requirements as needed.