### PR TITLE
Feat/forecast history api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,8 @@ config/local/
 context/
 context/*
 
+# Data generation output
+scripts/data-generation/out/
+
+# Forecast models
+services/forecast/models/

--- a/services/forecast/README.md
+++ b/services/forecast/README.md
@@ -50,6 +50,17 @@ Tips
   - For countable UoMs, daily and sum are rounded to integers; PI bounds are rounded >= 0
   - Tip: if Inventory has no recent data, pass `asOfDate` near last actuals
 
+### Forecast history APIs
+- GET `/forecast/history`
+  - Query: `productId` (required), `asOfFrom?`, `asOfTo?`, `horizonDays?`, `limit?=10`, `offset?=0`
+  - Response: list of run summaries: `{ forecastId, asOfDate, horizonDays, requestedAt, modelVersion, sumYhat }`
+- GET `/forecast/history/{forecastId}/items`
+  - Query: `productId` (required)
+  - Response: run detail with items: `{ forecastId, productId, asOfDate, horizonDays, requestedAt, modelVersion, items: [{date, yhat, lower, upper, confidence}] }`
+- GET `/forecast/history/latest`
+  - Query: `productId`, `asOfDate`, `horizonDays`
+  - Response: latest matching run detail (or null if none)
+
 ### Curl examples
 - Train (36 months, custom params):
 ```
@@ -66,6 +77,18 @@ curl -X POST 'http://127.0.0.1:8100/train/tune?trials=20&trainWindowDays=1095&se
 curl -X POST 'http://127.0.0.1:8100/forecast' \
   -H 'Content-Type: application/json' \
   -d '{"productIds":[1001,1008],"horizonDays":7,"asOfDate":"2025-06-30","returnDaily":true}'
+```
+- Forecast history (list last runs for product):
+```
+curl 'http://127.0.0.1:8100/forecast/history?productId=1001&horizonDays=7&limit=5'
+```
+- Forecast history (items for a run):
+```
+curl 'http://127.0.0.1:8100/forecast/history/123/items?productId=1001'
+```
+- Forecast history (latest by asOf/horizon):
+```
+curl 'http://127.0.0.1:8100/forecast/history/latest?productId=1001&asOfDate=2025-06-30&horizonDays=7'
 ```
 
 ## Notes

--- a/services/forecast/app/schemas.py
+++ b/services/forecast/app/schemas.py
@@ -54,3 +54,31 @@ class ForecastResponse(BaseModel):
     modelVersion: str = Field(default="xgb_three-latest", description="Model version used", example="xgb_three-20250913125620")
     modelType: Optional[str] = Field(default="xgb_three", description="Model algorithm type", example="xgb_three")
     generatedAt: datetime = Field(default_factory=lambda: datetime.utcnow(), description="Timestamp when forecast was generated")
+
+
+# History schemas
+class ForecastRunSummary(BaseModel):
+    forecastId: int = Field(description="Forecast header id", example=123)
+    asOfDate: Date = Field(description="As-of date used for this forecast", example="2025-06-30")
+    horizonDays: int = Field(description="Horizon length in days (1|7|14)", example=7)
+    requestedAt: datetime = Field(description="Timestamp when this forecast was computed", example="2025-09-13T09:00:00Z")
+    modelVersion: Optional[str] = Field(default=None, description="Version label of the model used", example="xgb_three-20250913125620")
+    sumYhat: float = Field(description="Sum of daily yhat for this product within the run", example=58.0)
+
+
+class ForecastHistoryItem(BaseModel):
+    date: Date = Field(description="Forecast date", example="2025-07-01")
+    yhat: float = Field(description="Predicted units for this date (rounded for countable UoMs)", example=8)
+    lower: Optional[float] = Field(default=None, description="Per-day lower bound (optional)", example=5)
+    upper: Optional[float] = Field(default=None, description="Per-day upper bound (optional)", example=12)
+    confidence: Optional[Dict[str, Any]] = Field(default=None, description="Confidence payload for this item (optional)", example={"score": 62, "level": "medium"})
+
+
+class ForecastRunDetail(BaseModel):
+    forecastId: int = Field(description="Forecast header id", example=123)
+    productId: int = Field(description="Product id for these items", example=1001)
+    asOfDate: Date = Field(description="As-of date the forecast was based on", example="2025-06-30")
+    horizonDays: int = Field(description="Horizon length in days (1|7|14)", example=7)
+    requestedAt: datetime = Field(description="Computation time of the run", example="2025-09-13T09:00:00Z")
+    modelVersion: Optional[str] = Field(default=None, description="Model version label used", example="xgb_three-20250913125620")
+    items: List[ForecastHistoryItem] = Field(description="Daily forecast items for the selected product and run")

--- a/services/forecast/setup.md
+++ b/services/forecast/setup.md
@@ -160,6 +160,15 @@ Forecast Service (FastAPI):
     - Rounding: for countable UoMs (adet, koli, paket, çuval, şişe) daily and sum are rounded to integers; PI bounds rounded ≥ 0.
     - Tip: if Inventory has no recent data (e.g., simulator ended), set `asOfDate` near the last actual date so lags/MA are informative.
 
+  - Forecast history (retrieve previous runs for a product)
+    - `GET /forecast/history` — list summaries
+      - Query: `productId` (required), `asOfFrom?`, `asOfTo?`, `horizonDays?`, `limit?=10`, `offset?=0`
+      - Returns: `[ { forecastId, asOfDate, horizonDays, requestedAt, modelVersion, sumYhat } ]`
+    - `GET /forecast/history/{forecastId}/items?productId=...` — run details with daily items
+      - Returns: `{ forecastId, productId, asOfDate, horizonDays, requestedAt, modelVersion, items: [{date, yhat, lower, upper, confidence}] }`
+    - `GET /forecast/history/latest?productId=...&asOfDate=...&horizonDays=...` — latest run by asOf/horizon
+      - Returns: the same run detail or null if none
+
 External (Inventory Service) — consumed by Forecast:
 - `GET /api/v1/reporting/product-day-sales?from&to&productId` — daily sales by product
 - `GET /api/v1/reporting/product-day-promo?from&to&productId` — daily promo percent by product


### PR DESCRIPTION
### What does this PR do?

  * Adds forecast history capabilities to the Forecast service:
      * New read APIs to list past runs, fetch run items, and get the latest run.
      * Persists `/forecast` outputs (header + items) when DB is configured.
  * Aligns history window with active `xgb_three` training window; rounds countable UoMs.
  * Documents endpoints, behavior, and examples.

### Why is this change needed?

  * Consumers need to audit, compare, and visualize prior forecasts by product, as-of date, and horizon.
  * “Latest” retrieval simplifies UI flows that display the most recent forecast.
  * Aligning the history window and rounding ensures consistent behavior with the active model and Inventory semantics.

### How can a reviewer test this?

## Prepare environment

Ensure Inventory reporting APIs are up (sales, promo, offer stats) and `forecast_db` is migrated then export env vars:

## Run the Forecast service

```bash
pip install -r services/forecast/requirements.txt
uvicorn services.forecast.app.main:app --port 8100 --workers 1
```

## Create a forecast (this persists a run)

**Expected**: 200 with per-product results; DB rows appear in `forecasts` and `forecast_items`.

## List history (summaries)

**Expected**: JSON array with `{forecastId, asOfDate, horizonDays, requestedAt, modelVersion, sumYhat}`.

## Fetch items for a run

**Expected**: `{ forecastId, productId, asOfDate, horizonDays, requestedAt, modelVersion, items:[{date,yhat,lower,upper,confidence}] }`.

If product’s UoM is countable (`adet`, `koli`, `paket`, `çuval`, `şişe`), verify `yhat` and PI bounds are integers ≥ 0.

## Get the latest run by asOf/horizon

**Expected**: same shape as step 5 (or `null` if none).

## Optional checks

  * Toggle `xgb_three` active model; confirm the history window in `/forecast` adapts to `max(365, training_window_days/3)`.
  * Test filters `asOfFrom`, `asOfTo`, and `horizonDays` in `/forecast/history` return expected subsets.