### PR TITLE
feat(planning/db): add initial plan_recommendations table (PoC) with …

### DIFF
--- a/services/planning/src/main/resources/db/migration/V1__plan_recommendations.sql
+++ b/services/planning/src/main/resources/db/migration/V1__plan_recommendations.sql
@@ -1,0 +1,49 @@
+-- Planning Service – Initial schema (PoC)
+-- Creates a single table to persist LLM-based recommendations per forecast+product.
+-- Postgres dialect.
+
+CREATE TABLE IF NOT EXISTS plan_recommendations (
+    plan_id           BIGSERIAL PRIMARY KEY,
+
+    -- Link back to the forecast run that this recommendation is for (no FK across DBs)
+    forecast_id       BIGINT NOT NULL,
+
+    -- Product being planned for
+    product_id        BIGINT NOT NULL,
+
+    -- Forecast context (denormalized for quick filtering/UX)
+    as_of_date        DATE   NOT NULL,
+    horizon_days      INTEGER NOT NULL DEFAULT 7 CHECK (horizon_days IN (1, 7, 14)),
+
+    -- Structured payload: includes the exact inputs (facts) and structured recommendation
+    -- Required keys: text (3–4 line human message), recommendation (structured fields)
+    -- e.g., { text: "...", facts: {...}, recommendation: { orderQty, orderDate, supplierId, confidence, assumptions, risks }, model: {...}, timings: {...} }
+    response_json     JSONB  NOT NULL,
+
+    -- Model metadata (for audit/demo)
+    model             VARCHAR(50) NOT NULL DEFAULT 'gemma-4b',
+
+    -- Creation timestamp
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Basic shape validation for JSON payload to avoid empty/no-text inserts
+    CONSTRAINT response_json_has_text CHECK (response_json ? 'text'),
+    CONSTRAINT response_json_has_recommendation CHECK (response_json ? 'recommendation')
+);
+
+-- Idempotency for webhook/UI retries: only one recommendation per (forecast_id, product_id)
+-- Note: Partial index guards when forecast_id is available.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_plan_recommendations_forecast_product
+    ON plan_recommendations (forecast_id, product_id);
+
+-- Useful filter for UI listings
+CREATE INDEX IF NOT EXISTS ix_plan_recommendations_product_asof
+    ON plan_recommendations (product_id, as_of_date DESC);
+
+-- Optional: index the human-readable text inside JSON for quick search
+CREATE INDEX IF NOT EXISTS ix_plan_recommendations_text
+    ON plan_recommendations ((response_json ->> 'text'));
+
+COMMENT ON TABLE plan_recommendations IS 'LLM-based replenishment recommendations keyed by forecast run and product';
+COMMENT ON COLUMN plan_recommendations.forecast_id IS 'Optional: forecast run id from Forecast service (not FK across DBs)';
+COMMENT ON COLUMN plan_recommendations.response_json IS 'Structured payload with facts, recommendation, model info, timings';


### PR DESCRIPTION
### What does this PR do?

This PR adds the initial Planning service schema migration (Flyway V1), creating a single table `plan_recommendations` to persist LLM-based recommendations for each forecast run and product.

**Table schema (PostgreSQL):**

  * `plan_id`: `BIGSERIAL` PK
  * `forecast_id`: `BIGINT NOT NULL`
  * `product_id`: `BIGINT NOT NULL`
  * `as_of_date`: `DATE NOT NULL`
  * `horizon_days`: `INTEGER NOT NULL DEFAULT 7`, CHECK IN (1,7,14)
  * `response_json`: `JSONB NOT NULL` with shape checks:
      * `response_json ? 'text'`
      * `response_json ? 'recommendation'`
  * `model`: `VARCHAR(50) NOT NULL DEFAULT 'gemma-4b'`
  * `created_at`: `TIMESTAMPTZ NOT NULL DEFAULT NOW()`

**Indexes/constraints:**

  * `UNIQUE` (`forecast_id`, `product_id`) — one recommendation per forecast run/product
  * `INDEX` (`product_id`, `as_of_date` DESC) — fast UI filtering
  * Expression `INDEX` on (`response_json->>'text'`) — quick text lookup

**File:** `services/planning/src/main/resources/db/migration/V1__plan_recommendations.sql`



### Why is this change needed?

  * We plan to generate a recommendation for each forecast run per product. Persisting it enables **auditability**, **idempotency** (one per run/product), and an easy UI read path.
  * Keeping the recommendation payload in `JSONB` (with required keys) provides forward-compatible flexibility to evolve facts and structured fields (e.g., `orderQty`, `orderDate`, `assumptions`, `risks`) without needing migrations.
  * Denormalized `as_of_date` and `horizon_days` support convenient filtering and reporting, but their source of truth will be the Forecast run header.


### How can a reviewer test this?

## Run the migration (via Flyway or psql)

If using Flyway with Spring Boot, starting the Planning service should apply V1 automatically or apply manually:

## Verify table and indexes

**Expect**: `unique index` on (`forecast_id`, `product_id`), `index` on (`product_id`, `as_of_date`), and `expression index` on (`response_json ->> 'text'`).

## Insert a valid sample row

**Expect**: `INSERT 0 1`.

## Check uniqueness constraint


-- Same forecast_id + product_id should fail

-- Expect: unique violation on (forecast_id, product_id)


## Check JSON shape enforcement


-- Missing 'text' key → should fail the CHECK constraint

-- Expect: CHECK constraint violation (response_json_has_text)

-- Missing 'recommendation' key → should fail the CHECK constraint

-- Expect: CHECK constraint violation (response_json_has_recommendation)
