### PR TITLE
fix(forecast): enable CORS for http://localhost:4200 to allow fronten…

### DIFF
--- a/services/forecast/app/main.py
+++ b/services/forecast/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse, Response
 
 from .routers.train import router as train_router
@@ -9,6 +10,16 @@ app = FastAPI(title="Forecast Service")
 
 app.include_router(train_router, prefix="/train", tags=["Train"])
 app.include_router(forecast_router, prefix="/forecast", tags=["Forecast"])
+
+
+# Allow the Angular dev server to access the API in the browser
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:4200"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/health")


### PR DESCRIPTION
## What does this PR do?
  - Enables CORS in `services/forecast/app/main.py` so the Angular frontend at `http://localhost:4200` can call the Forecast API.
## Why is this change needed?
  - Browser requests were blocked by CORS, causing forecast bars to show 0 even though curl succeeded.
##How can a reviewer test this?
  1. Restart Forecast service.
  2. From browser app at `http://localhost:4200`, open a product page with the sales chart.
  3. Verify the 7 and 14 day forecast bars render non-zero values.
  4. Network tab shows successful `POST /forecast` with 200.